### PR TITLE
fix: handle symbolic literal numbers in to_giac for Symbolics v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Giac"
 uuid = "e4421f97-9838-4fd0-9fa5-94f11373bf78"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Sébastien Celles <s.celles@gmail.com>"]
 
 [deps]

--- a/docs/src/extensions/symbolics.md
+++ b/docs/src/extensions/symbolics.md
@@ -176,6 +176,23 @@ poly = x^2 + 2*x + 1
 giac_poly = to_giac(poly)
 # Result: "1+x^2+2*x"
 
+# Power expressions work correctly
+squared = to_giac(x^2)
+# Result: "x^2"
+
+cubed = to_giac(x^3)
+# Result: "x^3"
+
+sum_of_squares = to_giac(x^2 + y^2)
+# Result: "x^2+y^2"
+
+# Compound expressions with powers
+compound = to_giac(sin(x)^2)
+# Result: "sin(x)^2"
+
+product = to_giac(x^2 * y)
+# Result: "x^2*y"
+
 # Mathematical functions are mapped correctly
 expr = sin(x) + cos(y)
 giac_expr = to_giac(expr)

--- a/ext/GiacSymbolicsExt.jl
+++ b/ext/GiacSymbolicsExt.jl
@@ -7,7 +7,7 @@ module GiacSymbolicsExt
 using Giac
 using Symbolics
 using CxxWrap: StdVector
-import Symbolics.SymbolicUtils: Sym, symtype, issym, iscall, operation, arguments
+import Symbolics.SymbolicUtils: Sym, symtype, issym, iscall, operation, arguments, is_literal_number, unwrap_const
 
 # ============================================================================
 # GIAC to Julia Name Mapping
@@ -184,6 +184,11 @@ function _convert_to_gen(expr)
         return Giac.GiacCxxBindings.make_complex(re_gen, im_gen)
     end
 
+    # Handle symbolic literal numbers (e.g., integer exponents in Symbolics v7)
+    if is_literal_number(unwrapped)
+        return _convert_to_gen(unwrap_const(unwrapped))
+    end
+
     # Handle symbolic variables (identifiers)
     if issym(unwrapped)
         name = String(Symbolics.tosymbol(unwrapped))
@@ -207,9 +212,9 @@ function _convert_to_gen(expr)
     end
 
     # Handle special constants
-    if unwrapped === π || unwrapped == Base.MathConstants.pi
+    if unwrapped === π || unwrapped === Base.MathConstants.pi
         return Giac.GiacCxxBindings.make_identifier("pi")
-    elseif unwrapped === ℯ || unwrapped == Base.MathConstants.e
+    elseif unwrapped === ℯ || unwrapped === Base.MathConstants.e
         return Giac.GiacCxxBindings.make_identifier("e")
     elseif unwrapped === im
         return Giac.GiacCxxBindings.make_identifier("i")

--- a/test/test_symbolics_ext.jl
+++ b/test/test_symbolics_ext.jl
@@ -341,4 +341,90 @@ using Symbolics.SymbolicUtils: Term
         end
     end
 
+    # ============================================================================
+    # Feature 063: Fix TypeError when converting power expressions (issue #1)
+    # ============================================================================
+    @testset "Feature 063: to_giac power expressions" begin
+        @variables a x y
+
+        # US1: Basic power expressions
+        @testset "US1: to_giac(a^2) — issue #1 reproducer" begin
+            result = to_giac(a^2)
+            @test result isa GiacExpr
+            @test occursin("a", string(result))
+            @test occursin("^", string(result)) || occursin("2", string(result))
+        end
+
+        @testset "US1: to_giac(x^3) — other integer exponents" begin
+            result = to_giac(x^3)
+            @test result isa GiacExpr
+            @test occursin("x", string(result))
+        end
+
+        @testset "US1: to_giac(x^2 + y^2) — sum of squares" begin
+            result = to_giac(x^2 + y^2)
+            @test result isa GiacExpr
+            result_str = string(result)
+            @test occursin("x", result_str)
+            @test occursin("y", result_str)
+        end
+
+        # US2: Compound expressions
+        @testset "US2: to_giac(sin(x)^2) — function with power" begin
+            result = to_giac(sin(x)^2)
+            @test result isa GiacExpr
+            result_str = string(result)
+            @test occursin("sin", result_str)
+        end
+
+        @testset "US2: to_giac(x^2 * y) — power with multiplication" begin
+            result = to_giac(x^2 * y)
+            @test result isa GiacExpr
+            result_str = string(result)
+            @test occursin("x", result_str)
+            @test occursin("y", result_str)
+        end
+
+        @testset "US2: to_giac((x + y)^2) — power of sum" begin
+            result = to_giac((x + y)^2)
+            @test result isa GiacExpr
+            result_str = string(result)
+            @test occursin("x", result_str)
+            @test occursin("y", result_str)
+        end
+
+        # US2: Edge cases
+        @testset "US2: edge cases — a^0, a^(-1), a^b" begin
+            @variables b
+
+            result_zero = to_giac(a^0)
+            @test result_zero isa GiacExpr
+
+            result_neg = to_giac(a^(-1))
+            @test result_neg isa GiacExpr
+
+            result_sym = to_giac(a^b)
+            @test result_sym isa GiacExpr
+            result_str = string(result_sym)
+            @test occursin("a", result_str)
+            @test occursin("b", result_str)
+        end
+
+        # US3: Roundtrip conversion
+        @testset "US3: roundtrip to_symbolics(to_giac(a^2))" begin
+            original = a^2
+            roundtrip = to_symbolics(to_giac(original))
+            @test roundtrip isa Num
+            # Verify mathematical equivalence by substituting a value
+            @test Symbolics.substitute(roundtrip, Dict(a => 3)) == Symbolics.substitute(original, Dict(a => 3))
+        end
+
+        @testset "US3: roundtrip to_symbolics(to_giac(x^2 + y))" begin
+            original = x^2 + y
+            roundtrip = to_symbolics(to_giac(original))
+            @test roundtrip isa Num
+            @test Symbolics.substitute(roundtrip, Dict(x => 2, y => 5)) == Symbolics.substitute(original, Dict(x => 2, y => 5))
+        end
+    end
+
 end  # @testset "Symbolics Extension"


### PR DESCRIPTION
Closes #1 

In Symbolics.jl v7, integer constants inside expression trees (e.g., the exponent 2 in a^2) are BasicSymbolic literal numbers rather than plain Julia integers. Added is_literal_number/unwrap_const handling to extract the underlying value. Also qualified substitute calls in roundtrip tests.

Bumps version to 0.11.1.