### PR TITLE
feat: add symbolic comparison operators (<, >, <=, >=) and logical operators (&, |) for GiacExpr

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Giac"
 uuid = "e4421f97-9838-4fd0-9fa5-94f11373bf78"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Sébastien Celles <s.celles@gmail.com>"]
 
 [deps]

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -1,4 +1,4 @@
-# Symbolic Variables
+# Symbolic variables
 
 ## Simple Variable Creation
 

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -1,4 +1,4 @@
-# Symbolic variables
+# Symbolic Variables
 
 ## Simple Variable Creation
 
@@ -53,3 +53,61 @@ for v in vars
     println(v)
 end
 ```
+
+## Symbolic Comparisons and Inequalities
+
+The comparison operators `<`, `>`, `<=`, `>=` return symbolic inequality expressions
+(`GiacExpr`), not booleans. This enables natural syntax for building constraints:
+
+```julia
+using Giac
+
+@giac_var x y
+
+# Build symbolic inequalities
+x > 0        # Returns a GiacExpr representing x>0
+x < y        # Returns a GiacExpr representing x<y
+x >= 1//2    # Works with Rational
+x <= π       # Works with Irrational
+```
+
+Combine inequalities with `&` (and) and `|` (or):
+
+```julia
+(x > 0) & (x < 10)    # GIAC "and" expression
+(x < -1) | (x > 1)    # GIAC "or" expression
+```
+
+## Assumptions on Variables
+
+Use `assume` and `additionally` to declare constraints on symbolic variables.
+Subsequent computations will respect these assumptions:
+
+```julia
+using Giac
+using Giac.Commands: assume, about, sign, purge, additionally, sqrt
+
+@giac_var x
+
+# Declare x as positive
+assume(x > 0)
+sign(x)      # Returns 1
+sqrt(x^2)    # Returns x (simplified thanks to assumption)
+
+# Interval constraint using &
+assume((x > 0) & (x < 10))
+about(x)     # Shows interval [0, 10]
+
+# Or use assume + additionally
+assume(x > -1)
+additionally(x < 1)
+about(x)     # Shows interval [-1, 1]
+
+# Clear assumptions
+purge(x)
+```
+
+!!! note
+    Julia's chained comparison syntax `0 < x < 10` does not work because Julia
+    desugars it using `&&` (which cannot be overloaded). Use `(x > 0) & (x < 10)`
+    or `assume` + `additionally` instead.

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -155,6 +155,136 @@ function Base.hash(expr::GiacExpr, h::UInt)::UInt
 end
 
 # =============================================================================
+# Symbolic Comparison Operators (064-symbolic-comparison-operators)
+# =============================================================================
+# These operators return GiacExpr (symbolic inequalities), NOT Bool.
+# This enables natural syntax like: assume(x > 0), additionally(x < 10)
+# Note: isless is intentionally NOT overridden to preserve sort/min/max semantics.
+
+"""
+    <(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Create a symbolic less-than inequality from two GIAC expressions.
+
+Returns a `GiacExpr` representing the inequality (not a `Bool`).
+
+# Examples
+```julia
+@giac_var x y
+ineq = x < y           # Creates symbolic inequality x<y
+assume(x < giac_eval("10"))  # Use with assume
+```
+"""
+function Base.:<(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("$(string(a))<$(string(b))")
+end
+
+"""
+    >(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Create a symbolic greater-than inequality from two GIAC expressions.
+
+Returns a `GiacExpr` representing the inequality (not a `Bool`).
+
+# Examples
+```julia
+@giac_var x y
+ineq = x > y           # Creates symbolic inequality x>y
+assume(x > giac_eval("0"))   # Assume x is positive
+```
+"""
+function Base.:>(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("$(string(a))>$(string(b))")
+end
+
+"""
+    <=(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Create a symbolic less-than-or-equal inequality from two GIAC expressions.
+
+Returns a `GiacExpr` representing the inequality (not a `Bool`).
+
+# Examples
+```julia
+@giac_var x y
+ineq = x <= y           # Creates symbolic inequality x<=y
+```
+"""
+function Base.:<=(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("$(string(a))<=$(string(b))")
+end
+
+"""
+    >=(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Create a symbolic greater-than-or-equal inequality from two GIAC expressions.
+
+Returns a `GiacExpr` representing the inequality (not a `Bool`).
+
+# Examples
+```julia
+@giac_var x y
+ineq = x >= y           # Creates symbolic inequality x>=y
+```
+"""
+function Base.:>=(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("$(string(a))>=$(string(b))")
+end
+
+# Mixed-type comparisons (GiacExpr with Julia numbers)
+Base.:<(a::GiacExpr, b::Number) = a < convert(GiacExpr, b)
+Base.:<(a::Number, b::GiacExpr) = convert(GiacExpr, a) < b
+
+Base.:>(a::GiacExpr, b::Number) = a > convert(GiacExpr, b)
+Base.:>(a::Number, b::GiacExpr) = convert(GiacExpr, a) > b
+
+Base.:<=(a::GiacExpr, b::Number) = a <= convert(GiacExpr, b)
+Base.:<=(a::Number, b::GiacExpr) = convert(GiacExpr, a) <= b
+
+Base.:>=(a::GiacExpr, b::Number) = a >= convert(GiacExpr, b)
+Base.:>=(a::Number, b::GiacExpr) = convert(GiacExpr, a) >= b
+
+# =============================================================================
+# Symbolic Logical Operators (064-symbolic-comparison-operators)
+# =============================================================================
+# These operators combine symbolic inequalities using GIAC's `and`/`or`.
+# Primary use case: assume((x > 0) & (x < 10)) for interval constraints.
+# Note: Julia's && and || cannot be overloaded (short-circuit operators),
+# so we use & and | (bitwise operators) instead.
+
+"""
+    &(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Combine two symbolic expressions with GIAC's logical `and`.
+
+This enables interval constraints with `assume`:
+
+# Examples
+```julia
+@giac_var x
+assume((x > 0) & (x < 10))   # x in (0, 10)
+```
+"""
+function Base.:&(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("($(string(a))) and ($(string(b)))")
+end
+
+"""
+    |(a::GiacExpr, b::GiacExpr) -> GiacExpr
+
+Combine two symbolic expressions with GIAC's logical `or`.
+
+# Examples
+```julia
+@giac_var x
+expr = (x < -1) | (x > 1)   # x outside [-1, 1]
+```
+"""
+function Base.:|(a::GiacExpr, b::GiacExpr)::GiacExpr
+    return giac_eval("($(string(a))) or ($(string(b)))")
+end
+
+# =============================================================================
 # Matrix Operators
 # =============================================================================
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,9 @@ using LinearAlgebra
     # Equation syntax tests (024-equation-syntax)
     include("test_equation_syntax.jl")
 
+    # Comparison operators tests (064-symbolic-comparison-operators)
+    include("test_comparison_operators.jl")
+
     # Tables.jl compatibility tests (025-tables-compatibility)
     include("test_tables.jl")
 

--- a/test/test_comparison_operators.jl
+++ b/test/test_comparison_operators.jl
@@ -1,0 +1,178 @@
+# Tests for symbolic comparison operators (064-symbolic-comparison-operators)
+# This file tests <, >, <=, >= operators returning GiacExpr for symbolic inequalities.
+
+using Test
+using Giac
+using Giac.Commands: assume, about, sign, purge, additionally
+
+@testset "Comparison Operators (064-symbolic-comparison-operators)" begin
+
+    # ========================================================================
+    # User Story 1: Build symbolic inequalities (Priority: P1) - MVP
+    # ========================================================================
+
+    @testset "US1: Less-than operator (<) between GiacExpr" begin
+        x = giac_eval("x")
+        y = giac_eval("y")
+        result = x < y
+        @test result isa GiacExpr
+        # GIAC may normalize x<y to y>x — check both representations
+        s = string(result)
+        @test occursin("<", s) || occursin(">", s)
+    end
+
+    @testset "US1: Greater-than operator (>) between GiacExpr" begin
+        x = giac_eval("x")
+        y = giac_eval("y")
+        result = x > y
+        @test result isa GiacExpr
+        @test occursin(">", string(result))
+    end
+
+    @testset "US1: Less-than-or-equal operator (<=) between GiacExpr" begin
+        x = giac_eval("x")
+        y = giac_eval("y")
+        result = x <= y
+        @test result isa GiacExpr
+        # GIAC may normalize x<=y to y>=x — check both representations
+        s = string(result)
+        @test occursin("<=", s) || occursin(">=", s)
+    end
+
+    @testset "US1: Greater-than-or-equal operator (>=) between GiacExpr" begin
+        x = giac_eval("x")
+        y = giac_eval("y")
+        result = x >= y
+        @test result isa GiacExpr
+        @test occursin(">=", string(result))
+    end
+
+    @testset "US1: Regression — existing operators unaffected" begin
+        x = giac_eval("x")
+        y = giac_eval("y")
+
+        # == still returns Bool
+        @test (x == x) isa Bool
+        @test x == x
+        @test !(x == y)
+
+        # ~ still returns GiacExpr
+        @test (x ~ y) isa GiacExpr
+
+        # hash still works for Dict/Set
+        d = Dict(x => 1, y => 2)
+        @test d[x] == 1
+        @test d[y] == 2
+        s = Set([x, y])
+        @test length(s) == 2
+    end
+
+    # ========================================================================
+    # User Story 2: Use with assume and additionally (Priority: P1)
+    # ========================================================================
+
+    @testset "US2: assume(x > 0) sets assumption" begin
+        x = giac_eval("x")
+        assume(x > 0)
+        @test sign(x) == giac_eval("1")
+        about_str = string(about(x))
+        @test occursin("assume", about_str)
+        purge(x)
+    end
+
+    @testset "US2: purge clears assumption" begin
+        x = giac_eval("x")
+        assume(x > 0)
+        purge(x)
+        @test string(about(x)) == "x"
+    end
+
+    @testset "US2: assume + additionally for interval constraints" begin
+        x = giac_eval("x")
+        assume(x > giac_eval("-1"))
+        additionally(x < giac_eval("1"))
+        about_str = string(about(x))
+        @test occursin("assume", about_str)
+        purge(x)
+    end
+
+    # ========================================================================
+    # User Story 3: Mixed-type comparisons (Priority: P2)
+    # ========================================================================
+
+    @testset "US3: GiacExpr vs Int" begin
+        x = giac_eval("x")
+        @test (x > 0) isa GiacExpr
+        @test (x < 0) isa GiacExpr
+        @test (x >= 1) isa GiacExpr
+        @test (x <= -1) isa GiacExpr
+    end
+
+    @testset "US3: Int vs GiacExpr" begin
+        x = giac_eval("x")
+        @test (0 < x) isa GiacExpr
+        @test (0 > x) isa GiacExpr
+        @test (1 <= x) isa GiacExpr
+        @test (-1 >= x) isa GiacExpr
+    end
+
+    @testset "US3: GiacExpr vs Float64" begin
+        x = giac_eval("x")
+        @test (x > 1.5) isa GiacExpr
+        @test (x < 1.5) isa GiacExpr
+    end
+
+    @testset "US3: GiacExpr vs Rational" begin
+        x = giac_eval("x")
+        @test (x > 1//2) isa GiacExpr
+        @test (x >= 1//3) isa GiacExpr
+    end
+
+    @testset "US3: GiacExpr vs Irrational" begin
+        x = giac_eval("x")
+        @test (x > π) isa GiacExpr
+        @test (x <= ℯ) isa GiacExpr
+    end
+
+    @testset "US3: Edge cases" begin
+        x = giac_eval("x")
+
+        # Self-comparison returns GiacExpr (not Bool)
+        result = x > x
+        @test result isa GiacExpr
+
+        # Infinity comparisons
+        @test (x > Inf) isa GiacExpr
+        @test (x < -Inf) isa GiacExpr
+    end
+
+    # ========================================================================
+    # Logical operators & and | for combining inequalities
+    # ========================================================================
+
+    @testset "Logical AND (&) between GiacExpr" begin
+        x = giac_eval("x")
+        result = (x > 0) & (x < 10)
+        @test result isa GiacExpr
+        s = string(result)
+        @test occursin("and", s)
+    end
+
+    @testset "Logical OR (|) between GiacExpr" begin
+        x = giac_eval("x")
+        result = (x < -1) | (x > 1)
+        @test result isa GiacExpr
+        s = string(result)
+        @test occursin("or", s)
+    end
+
+    @testset "assume with interval via & operator" begin
+        x = giac_eval("x")
+        assume((x > 0) & (x < 10))
+        @test sign(x) == giac_eval("1")
+        about_str = string(about(x))
+        @test occursin("assume", about_str)
+        purge(x)
+    end
+
+end


### PR DESCRIPTION
Enable natural Julia syntax for symbolic inequalities. Comparison operators return GiacExpr instead of Bool, allowing usage with assume/additionally. Add & (and) and | (or) for combining constraints like assume((x > 0) & (x < 10)). Mixed-type support for Int, Float64, Rational, Irrational in both operand orders.