### PR TITLE
add in some mathops

### DIFF
--- a/src/command_utils.jl
+++ b/src/command_utils.jl
@@ -281,6 +281,8 @@ result = sin(x^2)  # Works naturally with GiacExpr
 ```
 """
 Base.sin(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_sin_tier1, :sin, expr)
+Base.sind(expr::GiacExpr)::GiacExpr = sin(deg2rad(expr))
+Base.sinpi(expr::GiacExpr)::GiacExpr = sin(π * expr)
 
 """
     Base.cos(expr::GiacExpr) -> GiacExpr
@@ -289,6 +291,8 @@ Compute the cosine of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.cos(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_cos_tier1, :cos, expr)
+Base.cosd(expr::GiacExpr)::GiacExpr = cos(deg2rad(expr))
+Base.cospi(expr::GiacExpr)::GiacExpr = cos(π * expr)
 
 """
     Base.tan(expr::GiacExpr) -> GiacExpr
@@ -305,6 +309,7 @@ Compute the arc sine of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.asin(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_asin_tier1, :asin, expr)
+Base.asind(expr::GiacExpr)::GiacExpr = asin(deg2rad(expr))
 
 """
     Base.acos(expr::GiacExpr) -> GiacExpr
@@ -313,6 +318,7 @@ Compute the arc cosine of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.acos(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_acos_tier1, :acos, expr)
+Base.acosd(expr::GiacExpr)::GiacExpr = acos(deg2rad(expr))
 
 """
     Base.atan(expr::GiacExpr) -> GiacExpr
@@ -321,6 +327,19 @@ Compute the arc tangent of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.atan(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_atan_tier1, :atan, expr)
+Base.atand(expr::GiacExpr)::GiacExpr = atan(deg2rad(expr))
+
+Base.secd(expr::GiacExpr)::GiacExpr = sec(deg2rad(expr))
+Base.cscd(expr::GiacExpr)::GiacExpr = csc(deg2rad(expr))
+Base.cotd(expr::GiacExpr)::GiacExpr = cot(deg2rad(expr))
+
+Base.sincos(expr::GiacExpr)::GiacExpr = (sin(expr), cos(expr))
+Base.sincosd(expr::GiacExpr)::GiacExpr = (sind(expr), cosd(expr))
+Base.sincospi(expr::GiacExpr)::GiacExpr = (sinpi(expr), cospi(expr))
+
+
+Base.deg2rad(expr::GiacExpr)::GiacExpr = (expr*pi) / 180
+Base.rad2deg(expr::GiacExpr)::GiacExpr = (expr*180) / pi
 
 """
     Base.exp(expr::GiacExpr) -> GiacExpr
@@ -329,6 +348,8 @@ Compute the exponential of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.exp(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_exp_tier1, :exp, expr)
+Base.exp2(expr::GiacExpr)::GiacExpr = 2^expr
+Base.exp10(expr::GiacExpr)::GiacExpr = 10^expr
 
 """
     Base.log(expr::GiacExpr) -> GiacExpr
@@ -337,6 +358,10 @@ Compute the natural logarithm of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.log(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_ln_tier1, :ln, expr)
+Base.log1p(expr::GiacExpr)::GiacExpr = log(1 + expr)
+Base.log(b::GiacExpr, x::GiacExpr)::GiacExpr = log(x) / log(b)
+Base.log(b::Number, x::GiacExpr)::GiacExpr = log(promote(b, x)...)
+
 
 """
     Base.sqrt(expr::GiacExpr) -> GiacExpr
@@ -401,6 +426,7 @@ Compute the complex conjugate of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.conj(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_conj_tier1, :conj, expr)
+Base.adjoint(expr::GiacExpr)::GiacExpr = conj(expr)
 
 """
     Base.gcd(a::GiacExpr, b::GiacExpr) -> GiacExpr
@@ -433,3 +459,9 @@ collect(x^2 - 4x + 4)  # Returns (x-2)^2
 ```
 """
 Base.collect(expr::GiacExpr)::GiacExpr = giac_cmd(:collect, expr)
+
+
+Base.zero(::GiacExpr)::GiacExpr = giac_eval("0")
+Base.zero(::Type{GiacExpr})::GiacExpr = giac_eval("0")
+Base.one(::GiacExpr)::GiacExpr = giac_eval("1")
+Base.one(::Type{GiacExpr})::GiacExpr = giac_eval("1")

--- a/src/command_utils.jl
+++ b/src/command_utils.jl
@@ -309,7 +309,9 @@ Compute the arc sine of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.asin(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_asin_tier1, :asin, expr)
-Base.asind(expr::GiacExpr)::GiacExpr = asin(deg2rad(expr))
+# Inverse-degree trig: takes a value in [-1, 1] (or [0, ...) for atan), returns
+# the angle in degrees. Mirrors Julia Base: asind(x) = rad2deg(asin(x)).
+Base.asind(expr::GiacExpr)::GiacExpr = rad2deg(asin(expr))
 
 """
     Base.acos(expr::GiacExpr) -> GiacExpr
@@ -318,7 +320,7 @@ Compute the arc cosine of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.acos(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_acos_tier1, :acos, expr)
-Base.acosd(expr::GiacExpr)::GiacExpr = acos(deg2rad(expr))
+Base.acosd(expr::GiacExpr)::GiacExpr = rad2deg(acos(expr))
 
 """
     Base.atan(expr::GiacExpr) -> GiacExpr
@@ -327,15 +329,16 @@ Compute the arc tangent of a GiacExpr.
 Uses Tier 1 C++ wrapper for high performance.
 """
 Base.atan(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_atan_tier1, :atan, expr)
-Base.atand(expr::GiacExpr)::GiacExpr = atan(deg2rad(expr))
+Base.atand(expr::GiacExpr)::GiacExpr = rad2deg(atan(expr))
 
 Base.secd(expr::GiacExpr)::GiacExpr = sec(deg2rad(expr))
 Base.cscd(expr::GiacExpr)::GiacExpr = csc(deg2rad(expr))
 Base.cotd(expr::GiacExpr)::GiacExpr = cot(deg2rad(expr))
 
-Base.sincos(expr::GiacExpr)::GiacExpr = (sin(expr), cos(expr))
-Base.sincosd(expr::GiacExpr)::GiacExpr = (sind(expr), cosd(expr))
-Base.sincospi(expr::GiacExpr)::GiacExpr = (sinpi(expr), cospi(expr))
+# Paired trig — return a tuple of two GiacExpr (NOT a single GiacExpr).
+Base.sincos(expr::GiacExpr)::Tuple{GiacExpr, GiacExpr}    = (sin(expr), cos(expr))
+Base.sincosd(expr::GiacExpr)::Tuple{GiacExpr, GiacExpr}   = (sind(expr), cosd(expr))
+Base.sincospi(expr::GiacExpr)::Tuple{GiacExpr, GiacExpr}  = (sinpi(expr), cospi(expr))
 
 
 Base.deg2rad(expr::GiacExpr)::GiacExpr = (expr*pi) / 180

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -96,14 +96,18 @@ function Base.:^(a::GiacExpr, b::GiacExpr)::GiacExpr
 end
 
 """
-    ^(a::GiacExpr, n::Integer)
+    ^(a::GiacExpr, n::Number)
 
-Raise a GIAC expression to an integer power.
+Raise a GIAC expression to a power.
 """
-function Base.:^(a::GiacExpr, n::Integer)::GiacExpr
-    b = giac_eval(string(n))
-    return a^b
-end
+Base.:^(a::GiacExpr, b::Number) = ^(promote(a, b)...)
+
+"""
+    ^(a::Number, n::GiacExpr)
+
+Raise a number to a GIAC expression
+"""
+Base.:^(a::Number, b::GiacExpr) = ^(promote(a, b)...)
 
 # =============================================================================
 # Mixed-type arithmetic (GiacExpr with Julia numbers)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ using LinearAlgebra
     include("test_wrapper.jl")
     include("test_api.jl")
     include("test_operators.jl")
+    include("test_mathops.jl")
     include("test_calculus.jl")
     include("test_algebra.jl")
     include("test_linalg.jl")

--- a/test/test_mathops.jl
+++ b/test/test_mathops.jl
@@ -1,0 +1,168 @@
+# Tests for additional math operations on GiacExpr (PR #9 by @jverzani)
+# Covers: degree/pi trig variants, sec/csc/cot variants, sincos paired forms,
+# deg2rad/rad2deg, exp2/exp10/log1p/log(b,x), adjoint, zero/one, and the
+# widened ^ that accepts any Number on either side.
+
+using Giac.Commands: simplify
+
+@testset "Math Operations (PR #9)" begin
+
+    # ========================================================================
+    # Degree-based forward trig: sind, cosd, secd, cscd, cotd
+    # Implementation: sind(x) = sin(deg2rad(x)) etc.
+    # ========================================================================
+
+    @testset "Degree forward trig" begin
+        @test string(sind(giac_eval("30")))  == "1/2"
+        @test string(sind(giac_eval("90")))  == "1"
+        @test string(cosd(giac_eval("60")))  == "1/2"
+        @test string(cosd(giac_eval("0")))   == "1"
+        @test string(secd(giac_eval("60")))  == "2"
+        @test string(cscd(giac_eval("30")))  == "2"
+        @test string(cotd(giac_eval("45")))  == "1"
+    end
+
+    # ========================================================================
+    # Pi-multiple trig: sinpi, cospi
+    # Implementation: sinpi(x) = sin(pi*x), cospi(x) = cos(pi*x)
+    # ========================================================================
+
+    @testset "Pi-multiple trig" begin
+        @test string(sinpi(giac_eval("1/6")))  == "1/2"
+        @test string(sinpi(giac_eval("1/2")))  == "1"
+        @test string(cospi(giac_eval("1/3")))  == "1/2"
+        @test string(cospi(giac_eval("0")))    == "1"
+    end
+
+    # ========================================================================
+    # Degree-based inverse trig: asind, acosd, atand
+    # Implementation MUST be rad2deg(asin(x)) (NOT asin(deg2rad(x))).
+    # Note: GIAC keeps the literal 180/pi factor; simplify reduces to integer.
+    # ========================================================================
+
+    @testset "Degree inverse trig" begin
+        @test string(simplify(asind(giac_eval("1"))))   == "90"
+        @test string(simplify(asind(giac_eval("1/2")))) == "30"
+        @test string(simplify(acosd(giac_eval("0"))))   == "90"
+        @test string(simplify(acosd(giac_eval("1"))))   == "0"
+        @test string(simplify(atand(giac_eval("1"))))   == "45"
+        @test string(simplify(atand(giac_eval("0"))))   == "0"
+    end
+
+    # ========================================================================
+    # Paired trig: sincos, sincosd, sincospi
+    # Each MUST return a Tuple{GiacExpr, GiacExpr} (NOT a single GiacExpr).
+    # ========================================================================
+
+    @testset "Paired trig (tuples)" begin
+        @giac_var x
+
+        s, c = sincos(x)
+        @test s isa GiacExpr
+        @test c isa GiacExpr
+        @test string(s) == "sin(x)"
+        @test string(c) == "cos(x)"
+
+        sd, cd = sincosd(giac_eval("30"))
+        @test sd isa GiacExpr
+        @test cd isa GiacExpr
+        @test string(sd) == "1/2"
+        # cosd(30) = sqrt(3)/2; GIAC's exact form is "sqrt(3)/2"
+        @test string(cd) == "sqrt(3)/2"
+
+        sp, cp = sincospi(giac_eval("1/2"))
+        @test sp isa GiacExpr
+        @test cp isa GiacExpr
+        @test string(sp) == "1"
+        @test string(cp) == "0"
+    end
+
+    # ========================================================================
+    # Angle conversion: deg2rad, rad2deg
+    # ========================================================================
+
+    @testset "deg2rad / rad2deg" begin
+        @test string(simplify(deg2rad(giac_eval("180"))))   == "pi"
+        @test string(simplify(deg2rad(giac_eval("90"))))    == "pi/2"
+        @test string(simplify(rad2deg(giac_eval("pi"))))    == "180"
+        @test string(simplify(rad2deg(giac_eval("pi/2")))) == "90"
+    end
+
+    # ========================================================================
+    # Exponential / logarithm extensions
+    # ========================================================================
+
+    @testset "exp2 / exp10 / log1p" begin
+        @test string(exp2(giac_eval("3")))   == "8"
+        @test string(exp10(giac_eval("2")))  == "100"
+        @test string(log1p(giac_eval("0")))  == "0"
+    end
+
+    @testset "log(b, x) — arbitrary base" begin
+        # log(2, 8) == 3; GIAC may leave this as ln(8)/ln(2). simplify reduces.
+        @test string(simplify(log(giac_eval("2"), giac_eval("8")))) == "3"
+        @test string(simplify(log(giac_eval("10"), giac_eval("100")))) == "2"
+
+        # Number-base form also works (promotes the base to GiacExpr).
+        @giac_var x
+        r = log(2, x)
+        @test r isa GiacExpr
+        # Same value as log(giac_eval("2"), x).
+        @test string(simplify(r - log(giac_eval("2"), x))) == "0"
+    end
+
+    # ========================================================================
+    # adjoint (so postfix ' works on GiacExpr) — equivalent to conj
+    # ========================================================================
+
+    @testset "adjoint" begin
+        @giac_var x
+        @test string(adjoint(x)) == string(conj(x))
+        # Postfix ' uses adjoint
+        @test string(x') == string(conj(x))
+        # Conjugate of a real-typed variable is itself in GIAC's view
+        @test string(simplify(adjoint(giac_eval("3+4*i")))) == "3-4*i"
+    end
+
+    # ========================================================================
+    # zero / one — needed for Julia's identity-element machinery (matrices etc.)
+    # ========================================================================
+
+    @testset "zero / one" begin
+        @giac_var x
+        @test string(zero(x))            == "0"
+        @test string(zero(GiacExpr))     == "0"
+        @test string(one(x))             == "1"
+        @test string(one(GiacExpr))      == "1"
+        @test zero(x) isa GiacExpr
+        @test one(x) isa GiacExpr
+    end
+
+    # ========================================================================
+    # Power widening: GiacExpr^Number and Number^GiacExpr both work via promote.
+    # ========================================================================
+
+    @testset "Power widening" begin
+        @giac_var x
+
+        # GiacExpr ^ Integer (was the only form before PR #9; must still work).
+        @test string(x^2) == "x^2"
+        @test string(x^0) == "1"
+
+        # GiacExpr ^ Rational
+        @test string(x^(1//2)) == "sqrt(x)"
+
+        # GiacExpr ^ Float
+        @test x^2.0 isa GiacExpr
+
+        # Number ^ GiacExpr
+        @test 2^x isa GiacExpr
+        @test string(2^x) == "2^x"
+
+        # Float ^ GiacExpr
+        @test 2.5^x isa GiacExpr
+
+        # GiacExpr ^ GiacExpr (already supported pre-PR-9; no regression)
+        @test string(x^x) == "x^x"
+    end
+end


### PR DESCRIPTION
This adds some math operations and widens the types for `^`.

I didn't document the `sind` and `sinpi` variants, though would simply add them to the doc strings for `sin` if you thought that reasonable.

I didn't implement any tests. If you want those, let me know.