### PR TITLE
extend substitute syntax to more than one pair; add call method conve…

### DIFF
--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -116,6 +116,13 @@ substitute(x + 1, x => 5)  # Returns: 6
 function substitute(expr::GiacExpr, pair::Pair{<:GiacExpr})::GiacExpr
     return substitute(expr, Dict(pair))
 end
+function substitute(expr::GiacExpr, pairs::Pair{<:GiacExpr}...)::GiacExpr
+    for p ∈ pairs
+        expr = substitute(expr, p)
+    end
+    expr
+end
+
 
 # ============================================================================
 # GiacMatrix Support: Element-wise Substitution

--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -105,9 +105,17 @@ Substitute a single variable using Pair syntax.
 Convenience method equivalent to `substitute(expr, Dict(pair))`.
 
 # Examples
-```julia
-@giac_var x
-substitute(x + 1, x => 5)  # Returns: 6
+```jldoctest substitute
+julia> using Giac
+
+julia> @giac_var a b c x v₀ θ
+(a, b, c, x, v₀, θ)
+
+julia> substitute(a*x^2 + b*x + c, a => -32//2)
+GiacExpr: -16*x^2+b*x+c
+
+julia> substitute(a*x^2 + b*x + c, a => -32//2, b => v₀*cos(θ), c=>0)
+GiacExpr: -16*x^2+v₀*cos(θ)*x
 ```
 
 # See also

--- a/src/types.jl
+++ b/src/types.jl
@@ -298,6 +298,20 @@ function (expr::GiacExpr)(args...)
     return giac_eval(call_str)
 end
 
+"""
+    (expr::GiacExpr)(pairs::Pair{<:GiacExpr}...) -> GiacExpr
+
+Uses call syntax for `substitute` when arguments are pairs.
+
+# Examples
+```julia
+@giac_var a b c d t
+expr = a*sin(b*t + c) + d
+expr(a=>15, b=>10, c=>5, d=>0) # 15*sin(10*t+5)
+```
+"""
+(expr::GiacExpr)(pairs::Pair{<:GiacExpr}...)::GiacExpr = substitute(expr, pairs...)
+
 # ============================================================================
 # Derivative Operator D (035-derivative-operator)
 # ============================================================================

--- a/src/types.jl
+++ b/src/types.jl
@@ -304,10 +304,17 @@ end
 Uses call syntax for `substitute` when arguments are pairs.
 
 # Examples
-```julia
-@giac_var a b c d t
-expr = a*sin(b*t + c) + d
-expr(a=>15, b=>10, c=>5, d=>0) # 15*sin(10*t+5)
+```jldoctest call
+julia> using Giac
+
+julia> @giac_var a b c d t
+(a, b, c, d, t)
+
+julia> expr = a*sin(b*t + c) + d
+GiacExpr: a*sin(b*t+c)+d
+
+julia> expr(a=>15, b=>10, c=>5, d=>0)
+GiacExpr: 15*sin(10*t+5)
 ```
 """
 (expr::GiacExpr)(pairs::Pair{<:GiacExpr}...)::GiacExpr = substitute(expr, pairs...)


### PR DESCRIPTION
Extends the `substitute` syntax to multiple pairs of `Pair`s

Adds call syntax for symbolic expression when called with `Pair`s.

Again, I didn't include any tests, but can if you want.