### PR TITLE
test: enable doctests for Giac docstrings via Documenter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ Aqua = "0.8"
 CSV = "0.10"
 CxxWrap = "0.16, 0.17"
 DataFrames = "1.6, 1.7, 1.8"
+Documenter = "1"
 GIAC_jll = "2"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
@@ -40,9 +41,10 @@ libgiac_julia_jll = "0.5"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Symbolics", "MathJSON", "DataFrames", "CSV"]
+test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "DataFrames", "CSV"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,8 +4,11 @@ using Giac
 # Note: Giac.Commands is not imported here because it has ~2000 auto-generated
 # command functions. Their usage is documented in commands_submodule.md.
 
+DocMeta.setdocmeta!(Giac, :DocTestSetup, :(using Giac); recursive=true)
+
 makedocs(
     sitename = "Giac.jl",
+    doctest = true,
     # Note: Giac.Commands is excluded from modules because it has ~2000 auto-generated
     # command functions that aren't individually documented (usage is documented in
     # commands_submodule.md instead)

--- a/src/api.jl
+++ b/src/api.jl
@@ -17,14 +17,16 @@ Evaluate a GIAC expression string and return a GiacExpr.
 - `GiacError(:parse)`: If the expression cannot be parsed
 - `GiacError(:eval)`: If evaluation fails
 
-# Example
-```julia
-result = giac_eval("2 + 3")
-println(result)  # 5
+# Examples
+```jldoctest
+julia> giac_eval("2+3")
+GiacExpr: 5
 
-# Symbolic computation
-expr = giac_eval("diff(x^2, x)")
-println(expr)  # 2*x
+julia> giac_eval("diff(x^2, x)")
+GiacExpr: 2*x
+
+julia> giac_eval("factor(x^2-1)")
+GiacExpr: (x-1)*(x+1)
 ```
 """
 function giac_eval(expr::String, ctx::GiacContext=DEFAULT_CONTEXT[])::GiacExpr

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -32,31 +32,21 @@ Note: GIAC represents booleans as integers internally, but `to_julia` detects th
 via their string representation ("true"/"false") and returns Julia `Bool` values.
 
 # Examples
-```julia
-# Boolean conversion
-to_julia(giac_eval("true"))      # true::Bool
-to_julia(giac_eval("false"))     # false::Bool
-to_julia(giac_eval("1==1"))      # true::Bool (comparison result)
+```jldoctest
+julia> to_julia(giac_eval("42"))
+42
 
-# Integer conversion (distinct from booleans)
-to_julia(giac_eval("1"))         # Int64(1)
-to_julia(giac_eval("0"))         # Int64(0)
-to_julia(giac_eval("42"))        # Int64(42)
+julia> to_julia(giac_eval("3/4"))
+3//4
 
-# Float conversion
-to_julia(giac_eval("3.14"))      # Float64(3.14)
+julia> to_julia(giac_eval("[1,2,3]"))
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
 
-# Rational conversion
-to_julia(giac_eval("3/4"))       # 3//4
-
-# Complex conversion
-to_julia(giac_eval("3+4*i"))     # 3.0 + 4.0im
-
-# Vector conversion with type narrowing
-to_julia(giac_eval("[1, 2, 3]")) # [1, 2, 3]::Vector{Int64}
-
-# Symbolic expressions are unchanged
-to_julia(giac_eval("x + 1"))     # GiacExpr (unchanged)
+julia> to_julia(giac_eval("true"))
+true
 ```
 
 # See also

--- a/src/substitute.jl
+++ b/src/substitute.jl
@@ -61,12 +61,16 @@ expression is not modified.
 - `GiacExpr`: New expression with substitutions applied
 
 # Examples
-```julia
-@giac_var x y
-expr = x^2 + y
-substitute(expr, Dict(x => 2))        # Returns: 4 + y
-substitute(expr, Dict(x => 2, y => 3)) # Returns: 7
-substitute(expr, Dict(x => y, y => x)) # Swaps x and y: y^2 + x
+```jldoctest
+julia> @giac_var x y;
+
+julia> expr = x^2 + y;
+
+julia> string(substitute(expr, Dict(x => 2)))
+"4+y"
+
+julia> string(substitute(expr, Dict(x => 2, y => 3)))
+"7"
 ```
 
 # See also

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,6 +140,12 @@ using LinearAlgebra
     # Verifies bidirectional conversion between GiacExpr and MathJSON types
     # ============================================================================
     include("test_mathjson_conversion.jl")
+
+    # ============================================================================
+    # Doctests
+    # Runs jldoctest blocks in Giac docstrings via Documenter.doctest
+    # ============================================================================
+    include("test_doctests.jl")
 end
 
 # Aqua.jl package quality tests

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -1,0 +1,9 @@
+using Test
+using Documenter
+using Giac
+
+DocMeta.setdocmeta!(Giac, :DocTestSetup, :(using Giac); recursive=true)
+
+@testset "Doctests" begin
+    doctest(Giac; manual=false)
+end


### PR DESCRIPTION
Convert example blocks in giac_eval, to_julia, and substitute to jldoctest format and wire Documenter.doctest into the test suite so docstring examples are verified on every test run.