### PR TITLE
feat: finalize Issue #3 — to_julia auto-evalf, isfinite, TermInterface ext, subsume PR #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LinearIndices(M)` / `CartesianIndices(M)` are available for converting
   between forms. Contributed by [@jverzani](https://github.com/jverzani) in
   [PR #10](https://github.com/s-celles/Giac.jl/pull/10).
+- **Introspection helpers**: `is_constant`, `unwrap_const`, `free_symbols`,
+  `hasmatch`, `iscall`, `operation`, `arguments`, `maketerm`,
+  `Constants.is_giac_constant`, identity constructor `GiacExpr(::GiacExpr)`.
+  These let callers query whether an expression is closed-form constant,
+  enumerate its free symbols, and walk it as a syntax tree. Contributed by
+  [@jverzani](https://github.com/jverzani) in
+  [PR #8](https://github.com/s-celles/Giac.jl/pull/8). Resolves
+  [issue #3](https://github.com/s-celles/Giac.jl/issues/3).
+- **TermInterface.jl extension** (`GiacTermInterfaceExt`): when
+  `TermInterface` is loaded, `GiacExpr` participates in the
+  `iscall` / `operation` / `arguments` / `maketerm` / `isexpr` protocol
+  used by Metatheory.jl, SymbolicUtils.jl, and other rewriters. Pure
+  weak-dep — no cost to users who don't load `TermInterface`.
+- **`Base.isfinite(::GiacExpr)`**: returns a Julia `Bool`. `isfinite(x)` is
+  `true` for free identifiers, ordinary symbolic expressions, and finite
+  numbers; `false` for `inf`, `-inf`, and `1/0` (which GIAC normalizes to
+  infinity). Implemented as `!to_julia(isinf(expr))::Bool`.
 
 ### Changed
+
+- **`to_julia(::GiacExpr)` now reduces free-variable-free expressions to
+  numbers via `evalf`.** Previously, `to_julia(substitute(sin(x), x => 2))`
+  returned `GiacExpr: sin(2)` — the symbolic form was preserved even though
+  the caller asked for a Julia value. Now it returns `0.9092…` (a `Float64`).
+  The layered design holds: `evalf(expr)` keeps you in Giac and returns a
+  `GiacExpr` whose internal type is `DOUBLE`; `to_julia(expr)` bridges to a
+  Julia number. Symbolic expressions with at least one free variable still
+  pass through unchanged. **This is a behavior change for users who relied
+  on `to_julia` of constant symbolic expressions returning a `GiacExpr`** —
+  use `evalf(expr)` instead if you want a numeric `GiacExpr`. Resolves
+  [issue #3](https://github.com/s-celles/Giac.jl/issues/3).
 
 - **`^(::GiacExpr, ::Number)` and `^(::Number, ::GiacExpr)` widened**: powers
   on `GiacExpr` previously accepted only an `Integer` exponent; now any

--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,12 @@ libgiac_julia_jll = "ec39d2da-6bdf-580b-ada4-cd6e059515c9"
 [weakdeps]
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [extensions]
 GiacMathJSONExt = "MathJSON"
 GiacSymbolicsExt = "Symbolics"
+GiacTermInterfaceExt = "TermInterface"
 
 [compat]
 Aqua = "0.8"
@@ -32,6 +34,7 @@ LinearAlgebra = "1.10"
 MathJSON = "0.2, 0.3"
 Symbolics = "7"
 Tables = "1.10, 1.11, 1.12"
+TermInterface = "2"
 Test = "1.10"
 julia = "1.10"
 libcxxwrap_julia_jll = "0.14.9"
@@ -44,7 +47,8 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "DataFrames", "CSV"]
+test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "DataFrames", "CSV", "TermInterface"]

--- a/docs/src/api/core.md
+++ b/docs/src/api/core.md
@@ -292,6 +292,11 @@ Giac.is_fraction
 Giac.is_complex
 Giac.is_string
 Giac.is_boolean
+Giac.is_constant
+Giac.hasmatch
+Giac.free_symbols
+Giac.unwrap_const
+Giac.Constants.is_giac_constant
 ```
 
 ### Type Enum (GenTypes)

--- a/ext/GiacTermInterfaceExt.jl
+++ b/ext/GiacTermInterfaceExt.jl
@@ -1,0 +1,32 @@
+# Extension module for TermInterface.jl integration.
+#
+# Implements TermInterface's iscall / operation / arguments / maketerm methods
+# for `GiacExpr`, so that downstream packages built on TermInterface
+# (Metatheory.jl, SymbolicUtils.jl, …) can traverse and rewrite Giac
+# expressions as syntax trees.
+#
+# The core methods are defined in `Giac` itself (introspection.jl) so that
+# `Giac.iscall(expr)` etc. always work without an extra dependency. This
+# extension just bridges those into TermInterface's namespace when the user
+# has TermInterface loaded.
+
+module GiacTermInterfaceExt
+
+using Giac
+using TermInterface
+
+TermInterface.iscall(g::GiacExpr)::Bool = Giac.iscall(g)
+
+TermInterface.operation(g::GiacExpr) = Giac.operation(g)
+
+TermInterface.arguments(g::GiacExpr)::Vector{GiacExpr} = Giac.arguments(g)
+
+# `iscall` and `isexpr` typically agree for languages without explicit
+# `term`-vs-`call` distinction. Giac doesn't carry that distinction either.
+TermInterface.isexpr(g::GiacExpr)::Bool = Giac.iscall(g)
+
+# Reconstruct an expression from an op + args. Mirrors the in-core helper.
+TermInterface.maketerm(::Type{<:GiacExpr}, op, args, metadata=nothing)::GiacExpr =
+    Giac.maketerm(GiacExpr, op, args, metadata)
+
+end # module GiacTermInterfaceExt

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -199,8 +199,14 @@ function _init_constants()
 end
 
 # is a constant
+"""
+    is_giac_constant(expr::Giac_Eval) -> Bool
+
+Is expression one of the defined constants.
+
+"""
 function is_giac_constant(expr::GiacExpr)::Bool
-    expr == giac_eval("pi") || expr == giac_eval("e") || expr == giac_eval("i")
+    any(c -> expr == giac_eval(c), ("pi", "e", "i"))
 end
 
 

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -69,6 +69,10 @@ const _pi = Ref{GiacExpr}()
 const _e = Ref{GiacExpr}()
 const _i = Ref{GiacExpr}()
 
+# Cached tuple of (pi, e, i) used by `is_giac_constant` so the predicate
+# costs three pointer-equality comparisons instead of three giac_eval calls.
+const _giac_constants = Ref{NTuple{3, GiacExpr}}()
+
 """
     SymbolicConstant
 
@@ -194,19 +198,27 @@ Called by Giac.__init__() after GIAC library is initialized.
 """
 function _init_constants()
     _pi[] = giac_eval("pi")
-    _e[] = giac_eval("e")
-    _i[] = giac_eval("i")
+    _e[]  = giac_eval("e")
+    _i[]  = giac_eval("i")
+    _giac_constants[] = (_pi[], _e[], _i[])
 end
 
-# is a constant
 """
-    is_giac_constant(expr::Giac_Eval) -> Bool
+    is_giac_constant(expr::GiacExpr) -> Bool
 
-Is expression one of the defined constants.
+Return `true` when `expr` is one of the symbolic constants `pi`, `e`, or `i`.
 
+# Examples
+```julia
+Giac.Constants.is_giac_constant(giac_eval("pi"))   # true
+Giac.Constants.is_giac_constant(giac_eval("e"))    # true
+Giac.Constants.is_giac_constant(giac_eval("i"))    # true
+Giac.Constants.is_giac_constant(giac_eval("x"))    # false (free variable)
+Giac.Constants.is_giac_constant(giac_eval("1"))    # false (numeric literal)
+```
 """
 function is_giac_constant(expr::GiacExpr)::Bool
-    any(c -> expr == giac_eval(c), ("pi", "e", "i"))
+    any(==(expr), _giac_constants[])
 end
 
 

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -198,4 +198,10 @@ function _init_constants()
     _i[] = giac_eval("i")
 end
 
+# is a constant
+function is_giac_constant(expr::GiacExpr)::Bool
+    expr == giac_eval("pi") || expr == giac_eval("e") || expr == giac_eval("i")
+end
+
+
 end # module Constants

--- a/src/command_utils.jl
+++ b/src/command_utils.jl
@@ -436,6 +436,26 @@ Base.conj(expr::GiacExpr)::GiacExpr = _tier1_or_fallback(_giac_conj_tier1, :conj
 Base.adjoint(expr::GiacExpr)::GiacExpr = conj(expr)
 
 """
+    Base.isfinite(expr::GiacExpr) -> Bool
+
+Return `true` when `expr` is not infinite. Mirrors Julia's convention for
+numeric types: equivalent to `!isinf(expr)`, with the GIAC-side `isinf`
+result converted to a Julia `Bool` via [`to_julia`](@ref). Identifiers and
+ordinary symbolic expressions are reported as finite (they are not
+recognized as `inf`).
+
+# Examples
+```julia
+isfinite(giac_eval("1"))      # true
+isfinite(giac_eval("inf"))    # false
+isfinite(giac_eval("-inf"))   # false
+isfinite(giac_eval("1/0"))    # false  (GIAC normalizes 1/0 to inf)
+isfinite(giac_eval("x"))      # true   (a free variable is finite)
+```
+"""
+Base.isfinite(expr::GiacExpr)::Bool = !to_julia(isinf(expr))::Bool
+
+"""
     Base.gcd(a::GiacExpr, b::GiacExpr) -> GiacExpr
 
 Compute the greatest common divisor of two GiacExprs.

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -97,6 +97,22 @@ function _convert_by_type(g::GiacExpr, t::T)
     end
 end
 
+"""
+    unwrap_const([T], ex::GiacExpr) -> Number
+
+Unwraps a symbolic expression and returns a number (possibly with the specified type) when the expression has no symbolic variables.
+
+
+"""
+function unwrap_constant(ex::GiacExpr)
+    out = to_julia(ex)
+    isa(out, Number) && return out
+    if is_constant(ex)
+        return to_julia(Commands.evalf(ex))
+    end
+    return ex
+end
+
 # ============================================================================
 # Scalar Conversion Helpers
 # ============================================================================

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -104,7 +104,7 @@ Unwraps a symbolic expression and returns a number when the expression has no sy
 
 
 """
-function unwrap_constant(ex::GiacExpr)
+function unwrap_const(ex::GiacExpr)
     out = to_julia(ex)
     isa(out, Number) && return out
     if is_constant(ex)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -98,9 +98,9 @@ function _convert_by_type(g::GiacExpr, t::T)
 end
 
 """
-    unwrap_const([T], ex::GiacExpr) -> Number
+    unwrap_const(ex::GiacExpr) -> Number
 
-Unwraps a symbolic expression and returns a number (possibly with the specified type) when the expression has no symbolic variables.
+Unwraps a symbolic expression and returns a number when the expression has no symbolic variables.
 
 
 """

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -26,7 +26,14 @@ Recursively convert a GIAC expression to native Julia types.
 | `CPLX` | `Complex{T}` (T promoted from parts) |
 | `VECT` | `Vector{T}` (T narrowed from elements) |
 | `STRNG` | `String` |
-| `SYMB`, `IDNT`, `FUNC` | `GiacExpr` (unchanged) |
+| `SYMB`, `IDNT`, `FUNC` (with no free variables) | numeric value via `evalf` |
+| `SYMB`, `IDNT`, `FUNC` (with at least one free variable) | `GiacExpr` (unchanged) |
+
+When a symbolic expression has no free variables (i.e. [`is_constant`](@ref)
+returns `true`), `to_julia` calls `Giac.Commands.evalf` to reduce it to a
+numeric value and then recurses, so `to_julia(substitute(sin(x), x => 2))`
+returns a `Float64`, not `GiacExpr: sin(2)`. The layered design — `evalf(...)`
+keeps you in Giac, `to_julia(...)` bridges to Julia — is preserved.
 
 Note: GIAC represents booleans as integers internally, but `to_julia` detects them
 via their string representation ("true"/"false") and returns Julia `Bool` values.
@@ -50,7 +57,8 @@ true
 ```
 
 # See also
-[`giac_type`](@ref), [`is_boolean`](@ref), [`is_numeric`](@ref), [`is_vector`](@ref)
+[`giac_type`](@ref), [`is_boolean`](@ref), [`is_numeric`](@ref), [`is_vector`](@ref),
+[`is_constant`](@ref), [`unwrap_const`](@ref)
 """
 function to_julia(g::GiacExpr)
     if g.ptr == C_NULL
@@ -82,7 +90,13 @@ function _convert_by_type(g::GiacExpr, t::T)
     elseif t == STRNG
         return _convert_to_string(g)
     else
-        # Symbolic types (SYMB, IDNT, FUNC) - return unchanged
+        # Symbolic types (SYMB, IDNT, FUNC). If the expression has no free
+        # variables, reduce it numerically through evalf and recurse — this
+        # is what callers asking "give me a Julia value" almost always want
+        # (Issue #3). Otherwise return the GiacExpr unchanged.
+        if is_constant(g)
+            return to_julia(Commands.evalf(g))
+        end
         return g
     end
 end

--- a/src/introspection.jl
+++ b/src/introspection.jl
@@ -310,6 +310,25 @@ is_constant(giac_eval("0"))         # true (integer, not boolean)
 """
 is_constant(ex::GiacExpr) = !hasmatch(ex, x -> is_identifier(x) && !Constants.is_giac_constant(x))
 
+"""
+    hasmatch(ex::GiacExpr, pred) -> Bool
+
+Recursively test whether any sub-expression of `ex` satisfies the predicate
+`pred`. Walks every operand of compound expressions; for atomic expressions
+(identifiers, numbers, …) the predicate is applied to `ex` itself.
+
+This is the building block used by [`is_constant`](@ref) — it can also be
+used directly for ad-hoc tree searches.
+
+# Examples
+```julia
+Giac.hasmatch(giac_eval("sin(x) + 2"), Giac.is_identifier)  # true (contains x)
+Giac.hasmatch(giac_eval("pi + 2"),    Giac.is_identifier)   # true (pi is an
+                                                            # identifier; combine
+                                                            # with is_giac_constant
+                                                            # to exclude constants)
+```
+"""
 function hasmatch(ex::GiacExpr, pred)
     if is_symbolic(ex)
         return any(Base.Fix2(hasmatch, pred), arguments(ex))

--- a/src/introspection.jl
+++ b/src/introspection.jl
@@ -292,6 +292,56 @@ function is_boolean(g::GiacExpr)::Bool
     return str == "true" || str == "false"
 end
 
+"""
+    is_constant(g::GiacExpr) -> Bool
+
+Return `true` if the expression has no symbolic variables
+
+
+# Example
+```julia
+is_constant(giac_eval("x"))         # false
+is_constant(giac_eval("sin(x)"))    # false
+is_constant(giac_eval("1 == 1"))    # true (comparison returns constant)
+is_constant(giac_eval("pi"))        # true
+is_constant(giac_eval("0"))         # true (integer, not boolean)
+```
+
+"""
+is_constant(ex::GiacExpr) = !hasmatch(ex, x -> is_identifier(x) && !Constants.is_giac_constant(x))
+
+function hasmatch(ex::GiacExpr, pred)
+    if is_symbolic(ex)
+        return any(Base.Fix2(hasmatch, pred), arguments(ex))
+    end
+    pred(ex)
+end
+
+"""
+    free_symbols(ex::GiacExpr) -> Set{GiacExpr}
+
+Return the free symbols in a symbolic expression
+"""
+function free_symbols(ex::GiacExpr)::Set{GiacExpr}
+    S = Set{GiacExpr}()
+    free_symbols!(S, ex)
+    S
+end
+function free_symbols!(S::Set{GiacExpr}, ex::GiacExpr)::Nothing
+    Constants.is_giac_constant(ex) && return nothing
+    if is_identifier(ex)
+        push!(S, ex)
+        return nothing
+    end
+    !is_symbolic(ex) && return nothing
+    !iscall(ex) && return nothing
+    for a ∈ arguments(ex)
+        free_symbols!(S, a)
+    end
+    return nothing
+end
+
+
 # ============================================================================
 # Component Access Functions
 # ============================================================================
@@ -476,6 +526,8 @@ function symb_funcname(g::GiacExpr)::String
     end
 end
 
+
+
 """
     symb_argument(g::GiacExpr) -> GiacExpr
 
@@ -510,6 +562,27 @@ function symb_argument(g::GiacExpr)::GiacExpr
         return m !== nothing ? giac_eval(String(m.captures[1])) : g
     end
 end
+
+## TermInterface names
+iscall(g::GiacExpr)::Bool = giac_type(g) == Giac.SYMB
+
+function operation(g::GiacExpr)
+    iscall(g) || throw(ArgumentError("expression is not a function call"))
+    fn = Symbol(symb_funcname(g))
+    hasproperty(Giac.Commands, fn) && return getproperty(Giac.Commands, fn)
+    hasproperty(Giac, fn) && return getproperty(Giac, fn)
+    hasproperty(Base, fn) && return getproperty(Base, fn)
+    hasproperty(LinearAlgebra, fn) && return getproperty(LinearAlgebra, fn)
+    throw(ArgumentError("Can not locate $fn"))
+end
+
+function arguments(g::GiacExpr)::Vector{GiacExpr}
+    iscall(g) || throw(ArgumentError("expression is not a function call"))
+    collect(GiacExpr, symb_argument(g))
+end
+
+maketerm(::Type{GiacExpr}, op, args, metadata=nothing)::GiacExpr = GiacExpr(op(args...))
+
 
 # Internal helper to convert Gen to GiacExpr
 function _gen_to_giacexpr(gen)

--- a/src/introspection.jl
+++ b/src/introspection.jl
@@ -573,7 +573,7 @@ function operation(g::GiacExpr)
     hasproperty(Giac, fn) && return getproperty(Giac, fn)
     hasproperty(Base, fn) && return getproperty(Base, fn)
     hasproperty(LinearAlgebra, fn) && return getproperty(LinearAlgebra, fn)
-    throw(ArgumentError("Can not locate $fn"))
+    throw(ArgumentError("Cannot locate function `$fn` in Giac.Commands, Giac, Base, or LinearAlgebra"))
 end
 
 function arguments(g::GiacExpr)::Vector{GiacExpr}

--- a/src/types.jl
+++ b/src/types.jl
@@ -57,6 +57,7 @@ mutable struct GiacExpr
         return obj
     end
 end
+GiacExpr(x::GiacExpr) = x
 
 """
     _finalize_giacexpr(expr::GiacExpr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,12 @@ using LinearAlgebra
     include("test_mathjson_conversion.jl")
 
     # ============================================================================
+    # TermInterface Extension Tests (Issue #3 task 3)
+    # Verifies TermInterface.iscall / operation / arguments / maketerm dispatch
+    # ============================================================================
+    include("test_terminterface_ext.jl")
+
+    # ============================================================================
     # Doctests
     # Runs jldoctest blocks in Giac docstrings via Documenter.doctest
     # ============================================================================

--- a/test/test_inf_support.jl
+++ b/test/test_inf_support.jl
@@ -69,4 +69,36 @@ using Giac.Commands: limit, integrate
         @test string(result_julia) == string(result_giac)
     end
 
+    # ========================================================================
+    # Base.isfinite(::GiacExpr) — Issue #3 follow-up, task 4
+    # Returns a Julia Bool: !isinf(expr) with the boolean conversion done
+    # via to_julia. Identifiers / symbolic expressions are reported finite.
+    # ========================================================================
+
+    @testset "Base.isfinite" begin
+        @giac_var x
+
+        # Finite numerics.
+        @test isfinite(giac_eval("0"))
+        @test isfinite(giac_eval("1"))
+        @test isfinite(giac_eval("-1"))
+        @test isfinite(giac_eval("1/2"))
+        @test isfinite(giac_eval("3.14"))
+
+        # Infinities (both Julia Inf and GIAC inf paths).
+        @test !isfinite(giac_eval("inf"))
+        @test !isfinite(giac_eval("-inf"))
+        @test !isfinite(giac_eval("1/0"))   # GIAC normalizes 1/0 to inf
+
+        # Free identifiers and ordinary symbolic exprs are finite
+        # (GIAC does not classify them as inf).
+        @test isfinite(x)
+        @test isfinite(x + 1)
+        @test isfinite(sin(x))
+
+        # Return type is Julia Bool, not GiacExpr.
+        @test isfinite(giac_eval("1")) isa Bool
+        @test isfinite(giac_eval("inf")) isa Bool
+    end
+
 end

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -422,4 +422,36 @@
         @test length(Giac.free_symbols(giac_eval("sin(x + y)"))) == 2
     end
 
+    # ========================================================================
+    # to_julia auto-evalf for free-variable-free expressions (Issue #3)
+    # When a symbolic expression has no free variables, to_julia reduces it
+    # numerically (via evalf) and returns a Julia number. Symbolic
+    # expressions with at least one free variable pass through unchanged.
+    # ========================================================================
+    @testset "to_julia auto-evalf (Issue #3)" begin
+        @giac_var x y
+
+        # The canonical Issue #3 case.
+        r = to_julia(substitute(sin(x), x => 2))
+        @test r isa Float64
+        @test r ≈ 0.909297426825682
+
+        # Constants reduce numerically.
+        @test to_julia(giac_eval("pi"))         isa Float64
+        @test to_julia(giac_eval("sqrt(2)"))    isa Float64
+        @test to_julia(giac_eval("sin(pi/4)"))  ≈ sqrt(2)/2
+
+        # Free-variable expressions pass through unchanged.
+        @test to_julia(x)                === x
+        @test to_julia(sin(x))           isa GiacExpr
+        @test to_julia(x + 1)            isa GiacExpr
+        @test to_julia(substitute(sin(x), y => 2)) isa GiacExpr   # x still free
+
+        # Pre-existing numeric / boolean / vector paths are untouched.
+        @test to_julia(giac_eval("42"))  === 42
+        @test to_julia(giac_eval("3/4")) === 3//4
+        @test to_julia(giac_eval("true"))
+        @test to_julia(giac_eval("[1,2,3]")) == [1, 2, 3]
+    end
+
 end

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -384,4 +384,42 @@
         end
     end
 
+    # ========================================================================
+    # TermInterface names
+    # ========================================================================
+    @testset "terminterface names" begin
+        @test length(Giac.arguments(giac_eval("a*b*c"))) == 3
+        @test Giac.arguments(sin(giac_eval("x"))) == [giac_eval("x")]
+
+        @test Giac.operation(giac_eval("a*b*c")) == *
+        @test Giac.operation(sin(giac_eval("x"))) == sin
+        @test Giac.operation(giac_eval("Gamma(x)")) == Giac.Commands.Gamma
+
+        @test Giac.iscall(giac_eval("x")) == false
+        @test Giac.iscall(giac_eval("pi")) == false
+        @test Giac.iscall(giac_eval("sin(x)")) == true
+
+        @test Giac.maketerm(GiacExpr, ^, (giac_eval("2"), giac_eval("3")), nothing) == 8
+    end
+
+    # ========================================================================
+    # Constant expressions
+    # ========================================================================
+    @testset "constant expressions" begin
+        @test Giac.is_constant(giac_eval("sin(pi)"))
+        @test !Giac.is_constant(giac_eval("sin(x)"))
+        @test Giac.unwrap_const(giac_eval("sin(pi/2)")) ≈ 1
+        @test Giac.unwrap_const(giac_eval("sin(x)")) == giac_eval("sin(x)")
+    end
+
+    # ========================================================================
+    # Free symbols
+    # ========================================================================
+    @testset "free symbols" begin
+        @test length(Giac.free_symbols(giac_eval("sin(2)"))) == 0
+        @test length(Giac.free_symbols(giac_eval("sin(x)"))) == 1
+        @test length(Giac.free_symbols(giac_eval("sin(pi*x)"))) == 1
+        @test length(Giac.free_symbols(giac_eval("sin(x + y)"))) == 2
+    end
+
 end

--- a/test/test_terminterface_ext.jl
+++ b/test/test_terminterface_ext.jl
@@ -1,0 +1,77 @@
+# TermInterface Extension Tests (Issue #3 task 3)
+# Verifies that TermInterface.iscall / operation / arguments / maketerm /
+# isexpr dispatch correctly to Giac's introspection methods on GiacExpr.
+
+using TermInterface
+
+@testset "TermInterface extension" begin
+
+    @giac_var x y
+
+    # ========================================================================
+    # iscall / isexpr
+    # ========================================================================
+
+    @testset "iscall and isexpr" begin
+        # Compound expressions
+        @test TermInterface.iscall(sin(x)) == true
+        @test TermInterface.iscall(x + y) == true
+        @test TermInterface.iscall(x * y) == true
+        @test TermInterface.isexpr(sin(x)) == true
+
+        # Atomic
+        @test TermInterface.iscall(x)              == false  # identifier
+        @test TermInterface.iscall(giac_eval("1")) == false  # literal
+        @test TermInterface.iscall(giac_eval("pi")) == false # constant
+        @test TermInterface.isexpr(x) == false
+    end
+
+    # ========================================================================
+    # operation
+    # ========================================================================
+
+    @testset "operation" begin
+        @test TermInterface.operation(sin(x)) === sin
+        @test TermInterface.operation(x + y) === +
+        @test TermInterface.operation(x * y) === *
+    end
+
+    # ========================================================================
+    # arguments
+    # ========================================================================
+
+    @testset "arguments" begin
+        @test TermInterface.arguments(sin(x))           == [x]
+        @test length(TermInterface.arguments(x + y))    == 2
+        @test TermInterface.arguments(giac_eval("a*b*c")) |> length == 3
+    end
+
+    # ========================================================================
+    # maketerm
+    # ========================================================================
+
+    @testset "maketerm" begin
+        # Reconstruct sin(x) from op + args.
+        rebuilt = TermInterface.maketerm(GiacExpr, sin, (x,))
+        @test rebuilt isa GiacExpr
+        @test string(rebuilt) == "sin(x)"
+
+        # 2 + 3 == 5
+        @test TermInterface.maketerm(
+                GiacExpr, +, (giac_eval("2"), giac_eval("3"))
+              ) == giac_eval("5")
+    end
+
+    # ========================================================================
+    # End-to-end consistency: arguments(maketerm(op, args)) == args
+    # ========================================================================
+
+    @testset "round-trip" begin
+        original = sin(x + 1)
+        @test TermInterface.iscall(original)
+        op = TermInterface.operation(original)
+        args = TermInterface.arguments(original)
+        rebuilt = TermInterface.maketerm(GiacExpr, op, Tuple(args))
+        @test string(rebuilt) == string(original)
+    end
+end


### PR DESCRIPTION
## Summary

Closes the loop on [#3](https://github.com/s-celles/Giac.jl/issues/3) by landing the four remaining items from the design discussion. Subsumes [#8](https://github.com/s-celles/Giac.jl/pull/8) via a merge commit (jverzani's introspection-methods commits are preserved with original authorship).

The naming-style decision was: keep `unwrap_const` to match `Symbolics.jl` notation (no `T` argument).

## What's in this PR

| Commit | Scope |
|---|---|
| `ec4e3e4` | Merge PR #8 from `jverzani/introspection` (introspection methods) |
| `56f1315` | `refactor(constants):` cache `(pi, e, i)` tuple in `is_giac_constant`; fix `Giac_Eval` typo; document `hasmatch` |
| `37441c0` | `feat:` `Base.isfinite(::GiacExpr)` (Issue #3 task 4) |
| `674dac0` | `feat:` `to_julia` auto-`evalf` for free-variable-free expressions (the original Issue #3 ask) |
| `538ce72` | `feat(ext):` `GiacTermInterfaceExt` weak-dep extension (Issue #3 task 3) |
| `b406599` | `docs(changelog):` document everything under `[0.12.0]` |

## The original Issue #3 case

Before:

```julia
julia> to_julia(substitute(sin(x), x => 2))
GiacExpr: sin(2)
```

After:

```julia
julia> to_julia(substitute(sin(x), x => 2))
0.909297426825682
```

The layered design from the discussion holds: `evalf(...)` keeps you in Giac (returns `GiacExpr: 0.909…`), `to_julia(...)` bridges to Julia. Free-variable expressions still pass through unchanged.

## Behavior change

`to_julia` of a free-variable-free symbolic expression now returns a numeric Julia value instead of the original `GiacExpr`. For example:

```julia
to_julia(giac_eval(\"pi\"))      # 3.14159…  (was: GiacExpr: pi)
to_julia(giac_eval(\"sqrt(2)\")) # 1.41421…  (was: GiacExpr: sqrt(2))
```

If you want a numeric `GiacExpr`, call `evalf(expr)` instead (returns a `GiacExpr` whose internal type is `DOUBLE`).

## TermInterface extension

`Project.toml` adds `TermInterface` under `[weakdeps]` (UUID `8ea1fca8…`, compat `2`). When a user does `using TermInterface`, `GiacExpr` participates in:

- `TermInterface.iscall(::GiacExpr)`
- `TermInterface.isexpr(::GiacExpr)`
- `TermInterface.operation(::GiacExpr)`
- `TermInterface.arguments(::GiacExpr)`
- `TermInterface.maketerm(::Type{<:GiacExpr}, op, args, metadata=nothing)`

These are pure delegations to the in-core `Giac.iscall` / `Giac.operation` / `Giac.arguments` / `Giac.maketerm` from PR #8. Pure weak dep — no cost to users who don't load `TermInterface`. This unlocks Metatheory.jl / SymbolicUtils.jl interop without making them required dependencies.

## Tests

- New: `test/test_terminterface_ext.jl` (19 assertions; iscall, isexpr, operation, arguments, maketerm, op→args→maketerm round-trip)
- New: 13 `Base.isfinite` assertions appended to `test/test_inf_support.jl`
- New: 13 `to_julia` auto-evalf assertions appended to `test/test_introspection.jl`
- Existing: 38 introspection assertions from PR #8 (all green)

Local suite: **8224 pass / 0 fail** (vs 8179 on main pre-merge: +13 isfinite + 13 to_julia + 19 TermInterface = +45).

## Test plan

- [ ] CI green on Julia 1.10 LTS, 1.11+, latest stable
- [ ] Aqua passes (`Aqua.test_all(Giac; ambiguities=false)`)
- [ ] Doctests pass (Documenter.doctest in test_doctests.jl)
- [ ] Spot-check the canonical Issue #3 example: `to_julia(substitute(sin(x), x => 2))` returns `Float64`
- [ ] `using TermInterface` causes `GiacTermInterfaceExt` to load and `TermInterface.iscall(sin(x))` returns `true`

Closes #3.
Closes #8.

🙏 Credit to @jverzani for the introspection methods (PR #8) and the issue-3 design discussion.