### PR TITLE
feat: add MCP server extension for LLM-driven CAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ModelContextProtocol.jl` are unaffected — no transitive dependency, no
   precompilation cost. See `docs/src/extensions/mcp.md` for the full setup
   guide.
+- **Example MCP prompts in the documentation**: `docs/src/extensions/mcp.md`
+  now ships a curated "Example prompts" gallery — French and English
+  direct-style prompts (`factorise avec giac x²-1`, `with giac, factor
+  x^4 - 1`) plus natural-language, story-style prompts that exercise the
+  LLM's judgement when routing to `giac_eval` (e.g., *"between which two
+  integers does the real root of x^3 + x - 1 = 0 lie?"*, *"my password is
+  the prime just after one billion — what is it?"*). A separate
+  `giac_search` block shows catalogue-discovery prompts
+  (*"which commands deal with matrices?"*).
 
 ## [0.14.1] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP server integration**: `giac_mcp_server()` exposes Giac's CAS engine
+  to MCP-aware LLM clients (Claude Desktop, Claude Code, Cursor, …) through
+  a new weak-dependency package extension `GiacMCPExt` on
+  [`ModelContextProtocol.jl`](https://github.com/JuliaSMLM/ModelContextProtocol.jl).
+  The server advertises two tools — `giac_eval` (Giac/Xcas expression in →
+  textual result out, with `CallToolResult(isError=true, ...)` for genuine
+  Julia exceptions) and `giac_search` (keyword in → matching command names
+  out, with a prefix-then-substring fallback so LLM-style queries like
+  `"matrix"` or `"prime"` surface relevant commands). The MCP `initialize`
+  handshake's `serverInfo.version` defaults to the running Giac.jl version
+  so clients always see the right number. Users who do not load
+  `ModelContextProtocol.jl` are unaffected — no transitive dependency, no
+  precompilation cost. See `docs/src/extensions/mcp.md` for the full setup
+  guide.
+
 ## [0.14.1] - 2026-05-10
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,12 @@ libgiac_julia_jll = "ec39d2da-6bdf-580b-ada4-cd6e059515c9"
 
 [weakdeps]
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
+ModelContextProtocol = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [extensions]
+GiacMCPExt = "ModelContextProtocol"
 GiacMathJSONExt = "MathJSON"
 GiacSymbolicsExt = "Symbolics"
 GiacTermInterfaceExt = "TermInterface"
@@ -35,6 +37,7 @@ GIAC_jll = "2"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
 MathJSON = "0.2, 0.3"
+ModelContextProtocol = "0.4"
 Random = "1.10"
 Symbolics = "7"
 Tables = "1.10, 1.11, 1.12"
@@ -51,10 +54,11 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
+ModelContextProtocol = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "DataFrames", "CSV", "TermInterface", "Random", "ForwardDiff"]
+test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "ModelContextProtocol", "DataFrames", "CSV", "TermInterface", "Random", "ForwardDiff"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,49 @@
 
 A Julia wrapper for the [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) computer algebra system.
 
+## MCP Server (LLM Integration)
+
+Giac.jl can expose its CAS engine to MCP-aware LLM clients (Claude Desktop,
+Claude Code, Cursor, …) via the
+[Model Context Protocol](https://modelcontextprotocol.io). The integration
+is a weak-dependency package extension on
+[`ModelContextProtocol.jl`](https://github.com/JuliaSMLM/ModelContextProtocol.jl),
+so users who do not need MCP pay no cost.
+
+```julia
+using Pkg; Pkg.add("ModelContextProtocol")   # one-time setup
+using Giac, ModelContextProtocol
+start!(giac_mcp_server())                    # blocks on STDIO transport
+```
+
+### Claude Desktop
+
+Add to `~/.config/claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "giac-cas": {
+      "command": "julia",
+      "args": [
+        "--project=/path/to/env",
+        "-e",
+        "using Giac, ModelContextProtocol; start!(giac_mcp_server())"
+      ]
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add-json "giac-cas" '{"command":"julia","args":["--project=/path/to/env","-e","using Giac, ModelContextProtocol; start!(giac_mcp_server())"]}'
+```
+
+See [`docs/src/extensions/mcp.md`](docs/src/extensions/mcp.md) for the full
+setup guide, manual JSON-RPC test, and the list of advertised tools.
+
 ## Contributors
 
 See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the people who built, reviewed,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,6 +53,7 @@ makedocs(
         "Extensions" => [
              "Symbolics.jl" => "extensions/symbolics.md",
              "MathJSON.jl" => "extensions/mathjson.md",
+             "MCP Server" => "extensions/mcp.md",
         ],
         "Developer Guide" => [
             "Overview" => "developer/index.md",

--- a/docs/src/extensions/mcp.md
+++ b/docs/src/extensions/mcp.md
@@ -113,6 +113,71 @@ The output is two JSON-RPC response objects: the `initialize` reply and the
 `tools/call` reply whose `content[0].text` contains Giac's factored form
 of `x^4 - 1`.
 
+## Example prompts
+
+Once the server is wired into your MCP client, you can address it in plain
+natural language. The LLM routes the request to `giac_eval` (or
+`giac_search`) and returns Giac's exact symbolic result. A few prompts to
+get started, grouped by domain:
+
+### French — direct style
+
+- `factorise avec giac x²-1`
+- `développe avec giac (a+b)²`
+- `résous avec giac x² - 5x + 6 = 0`
+- `dérive avec giac sin(x²)`
+- `intègre avec giac x·exp(x)`
+- `calcule avec giac la limite de sin(x)/x en 0`
+- `décompose avec giac 1/(x³-1) en éléments simples`
+
+### English — direct style
+
+- `with giac, factor x^4 - 1`
+- `with giac, expand (x+y+z)^3`
+- `with giac, solve x^3 - 6x^2 + 11x - 6 = 0`
+- `with giac, integrate 1/(x^2 + 2x + 5) dx`
+- `with giac, compute the Laplace transform of t^2 * exp(-t) * sin(t)`
+- `with giac, compute the Z-transform of n^2`
+
+### English — natural, story-style
+
+These read like questions a human would actually ask. The LLM still routes
+them through `giac_eval`, but the framing exercises its judgement about
+which Giac construct to invoke.
+
+- `with giac, I'm stuck on x^4 - 5x^2 + 4 — can you break it into factors?`
+- `with giac, between which two integers does the real root of x^3 + x - 1 = 0 lie?`
+- `with giac, what's the slope of tan(x^2) at x = 1?`
+- `with giac, give me the area under the bell curve exp(-x^2) over the whole real line`
+- `with giac, does the sequence (1 + 1/n)^n converge, and to what?`
+- `with giac, a mass on a spring satisfies y'' + 4y = cos(2t) — find the motion`
+- `with giac, a population grows logistically with y' = y(1-y) and starts at 1/2; what's y(t)?`
+- `with giac, is the matrix [[1,2,3],[4,5,6],[7,8,10]] invertible? Prove it`
+- `with giac, the matrix [[2,1,0],[0,2,1],[0,0,2]] isn't diagonalizable — what's its Jordan structure?`
+- `with giac, what polynomial of degree 3 passes through (0,1), (1,2), (2,5), (3,10)?`
+- `with giac, do x^2 + x + 1 and x^3 - 1 share a common root?`
+- `with giac, my password is the prime just after one billion — what is it?`
+- `with giac, is the Mersenne number 2^31 - 1 actually prime?`
+- `with giac, find integers u and v such that 1071·u + 462·v = gcd(1071, 462)`
+- `with giac, an engineer needs the Laplace transform of t² e^(-t) sin(t) — deliver it`
+- `with giac, recover the time-domain signal whose Laplace transform is (s+1)/((s²+1)(s+2))`
+- `with giac, rewrite sin(5x) using only sin(x) and cos(x)`
+- `with giac, fuse sin(x) + cos(x) into a single sinusoid`
+- `with giac, how many 5-card poker hands are there from a standard deck?`
+- `with giac, give me the 50th Fibonacci number`
+- `with giac, fit a line through (1,2), (2,5), (3,7), (4,10) and tell me the slope`
+- `with giac, Euler famously summed 1/k² — confirm his answer`
+- `with giac, give me a closed-form expression for 1³ + 2³ + … + n³`
+- `with giac, does the alternating sum (-1)^k / k converge, and to what value?`
+
+### Catalogue search
+
+Use the `giac_search` tool when you don't remember the exact command name:
+
+- `with giac, which commands deal with matrices?`
+- `with giac, what's available for prime numbers?`
+- `with giac, list the Laplace-related commands`
+
 ## API reference
 
 ```@docs

--- a/docs/src/extensions/mcp.md
+++ b/docs/src/extensions/mcp.md
@@ -1,0 +1,135 @@
+# MCP Server (LLM Integration)
+
+Giac.jl can expose its computer-algebra engine to MCP-aware LLM clients
+(Claude Desktop, Claude Code, Cursor, and others) through the
+[Model Context Protocol](https://modelcontextprotocol.io). The integration
+is implemented as a **weak-dependency package extension**: users who do
+not need MCP see no behavior change, no new dependency in their manifest,
+and no precompilation cost.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("ModelContextProtocol")
+```
+
+`Giac.jl` itself does NOT pull `ModelContextProtocol.jl` in transitively.
+You install it explicitly when (and only when) you want the MCP server.
+
+## Quickstart
+
+```julia
+using Giac, ModelContextProtocol
+
+server = giac_mcp_server()   # construct the server (no I/O yet)
+start!(server)                # blocks on STDIO transport
+```
+
+`start!` reads JSON-RPC requests from stdin, writes responses to stdout,
+and logs to stderr. Press Ctrl-C to stop.
+
+## What tools are exposed
+
+The returned `Server` advertises two MCP tools:
+
+- **`giac_eval`** — evaluate any Giac/Xcas expression. Input: `expr` (string).
+  Output: the textual result of the expression.
+
+  ```text
+  expr = "factor(x^4-1)"   →   (x-1)*(x+1)*(x^2+1)
+  expr = "laplace(exp(-t),t,s)"   →   1/(s+1)
+  ```
+
+  Multiple statements separated by `;` are allowed; the response is the
+  value of the last statement. Each tool call is **independent** —
+  variable bindings (`a := 5`) do NOT persist across calls.
+
+- **`giac_search`** — search the Giac command catalogue by keyword. Input:
+  `query` (string). Output: comma-separated list of matching command names,
+  or the literal `"No commands matched."` when nothing matches.
+
+  The search first tries prefix matching (the canonical Giac.jl behavior)
+  and falls back to substring matching so LLM-style queries like
+  `"matrix"` or `"prime"` find the relevant commands.
+
+## Setup with Claude Desktop
+
+Edit `~/.config/claude/claude_desktop_config.json` (or the platform
+equivalent) and add a `mcpServers` entry:
+
+```json
+{
+  "mcpServers": {
+    "giac-cas": {
+      "command": "julia",
+      "args": [
+        "--project=/path/to/env",
+        "-e",
+        "using Giac, ModelContextProtocol; start!(giac_mcp_server())"
+      ]
+    }
+  }
+}
+```
+
+Substitute `/path/to/env` with a Julia environment that has both `Giac` and
+`ModelContextProtocol` installed. A dedicated environment (for example
+`~/.julia/environments/mcp-giac/`) is recommended so the MCP server starts
+as quickly as Julia allows. Restart Claude Desktop after editing the config.
+
+## Setup with Claude Code
+
+```bash
+claude mcp add-json "giac-cas" '{"command":"julia","args":["--project=/path/to/env","-e","using Giac, ModelContextProtocol; start!(giac_mcp_server())"]}'
+```
+
+Confirm with `claude mcp list`. From any Claude Code session, ask:
+
+> Use the Giac MCP server to factor `x^4 - 1`.
+
+and Claude will call the `giac_eval` tool and return the Giac-computed
+factorization.
+
+## Setup with other MCP clients (Cursor, ...)
+
+The command is the same — only the configuration UI differs. Most clients
+accept a JSON object with a `command` and `args` array; copy the structure
+from the Claude Desktop section.
+
+## Manual JSON-RPC test
+
+To verify the server end-to-end without an LLM client:
+
+```bash
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"giac_eval","arguments":{"expr":"factor(x^4-1)"}},"id":2}' \
+| julia --project -e 'using Giac, ModelContextProtocol; start!(giac_mcp_server())' \
+  2>/dev/null | jq .
+```
+
+The output is two JSON-RPC response objects: the `initialize` reply and the
+`tools/call` reply whose `content[0].text` contains Giac's factored form
+of `x^4 - 1`.
+
+## API reference
+
+```@docs
+giac_mcp_server
+```
+
+## Limitations and future work
+
+The first release is intentionally minimal. Deferred to later iterations:
+
+- **MCP `Resource`s** that expose Giac documentation by domain so the LLM
+  can fetch reference material on demand.
+- **MCP `Prompt`s** offering pre-built templates such as
+  "solve step by step, verify each step with `giac_eval`".
+- A **structured invocation tool** accepting `{"command": "factor", "args": ["x^4-1"]}`
+  for callers that want typed arguments instead of free-form expressions.
+- **Session/context state** across tool calls (e.g., `a := 5` persisting).
+  Each tool call is currently independent.
+- A **`PackageCompiler.jl` sysimage** to reduce Julia's startup latency
+  when an LLM client launches the server as a subprocess.

--- a/ext/GiacMCPExt.jl
+++ b/ext/GiacMCPExt.jl
@@ -1,0 +1,153 @@
+# Extension module for ModelContextProtocol.jl integration.
+# Exposes Giac's CAS engine to MCP-aware LLM clients (Claude Desktop, Claude Code, ...).
+# Activated automatically when both `Giac` and `ModelContextProtocol` are loaded.
+
+module GiacMCPExt
+
+using Giac
+using Giac: giac_eval, search_commands
+using ModelContextProtocol
+
+# ============================================================================
+# Tool and server descriptions
+# ============================================================================
+
+const _SERVER_DESCRIPTION = """
+Computer Algebra System server powered by Giac/Xcas. Provides exact symbolic \
+computation through ~2200 commands: algebra, calculus, differential equations, \
+Laplace/Z-transforms, linear algebra, number theory, and more.
+"""
+
+const _EVAL_DESCRIPTION = """
+Evaluate any expression using the Giac/Xcas computer algebra system (~2200 functions).
+Syntax follows Xcas conventions.
+
+Domains and example expressions:
+- Algebra: factor(x^4-1), expand((x+1)^3), simplify((x^2-1)/(x-1))
+- Equations: solve(x^2-3*x+2=0, x), linsolve([x+y=1, x-y=3], [x,y])
+- Calculus: diff(sin(x^2), x), integrate(x*exp(x), x), limit(sin(x)/x, x, 0), series(exp(x), x, 0, 5)
+- Differential equations: desolve(y'+y=sin(x), y)
+- Laplace/Z: laplace(sin(t), t, s), ilaplace(1/(s^2+1), s, t), ztrans(1, n, z), invztrans(z/(z-1), z, n)
+- Linear algebra: det([[1,2],[3,4]]), inv([[a,b],[c,d]]), eigenvalues([[1,2],[3,4]]), jordan([[2,1],[0,2]])
+- Number theory: ifactor(2310), isprime(17), nextprime(100)
+- Polynomials: partfrac(1/(x^3-1), x), gcd(x^4-1, x^2-1), roots(x^3-6*x^2+11*x-6), resultant(x^2-1, x^2-4, x)
+- Trigonometry: trigexpand(sin(2*x)), tlin(sin(x)^2)
+- Combinatorics: comb(10,3), perm(5,2), factorial(10)
+- Statistics: mean([1,2,3,4]), stddev([1,2,3,4])
+
+Multiple statements can be separated by semicolons; the result is the value of the last one.
+Variables are symbolic by default.
+Each call is independent — variable bindings (a := 5) do NOT persist across calls.
+"""
+
+const _SEARCH_DESCRIPTION = """
+Search the Giac command catalogue by keyword. Returns matching command names as a \
+comma-separated list, or the literal "No commands matched." when nothing matches.
+
+Use this to discover the right Giac function for a given task when you are unsure of \
+the exact name.
+
+Examples:
+- query="laplace" -> laplace, ilaplace
+- query="matrix"  -> det, inv, eigenvalues, ...
+"""
+
+# ============================================================================
+# Tool factories
+# ============================================================================
+
+function _make_eval_tool()
+    return MCPTool(
+        name = "giac_eval",
+        description = _EVAL_DESCRIPTION,
+        parameters = [
+            ToolParameter(
+                name = "expr",
+                type = "string",
+                description = "Any valid Giac/Xcas expression",
+                required = true,
+            ),
+        ],
+        handler = function (params)
+            try
+                result = giac_eval(params["expr"])
+                return TextContent(text = string(result))
+            catch e
+                return CallToolResult(
+                    isError = true,
+                    content = Content[TextContent(text = "Error: " * sprint(showerror, e))],
+                )
+            end
+        end,
+    )
+end
+
+function _make_search_tool()
+    return MCPTool(
+        name = "giac_search",
+        description = _SEARCH_DESCRIPTION,
+        parameters = [
+            ToolParameter(
+                name = "query",
+                type = "string",
+                description = "Keyword to search for in Giac command names.",
+                required = true,
+            ),
+        ],
+        handler = function (params)
+            try
+                query = params["query"]
+                # Two-tier search: prefix first (canonical Giac.jl semantics),
+                # then substring fallback so LLM-style queries like "matrix" or
+                # "prime" surface the right commands even when the keyword is
+                # not at the start of the name.
+                results = search_commands(query)
+                if isempty(results)
+                    escaped = replace(query, r"([.*+?^${}()|\[\]\\])" => s"\\\1")
+                    results = search_commands(Regex(escaped))
+                end
+                if isempty(results)
+                    return TextContent(text = "No commands matched.")
+                end
+                return TextContent(text = join(string.(results), ", "))
+            catch e
+                return CallToolResult(
+                    isError = true,
+                    content = Content[TextContent(text = "Error: " * sprint(showerror, e))],
+                )
+            end
+        end,
+    )
+end
+
+# ============================================================================
+# Public entry point
+# ============================================================================
+
+"""
+    Giac.giac_mcp_server(; name="giac-cas", kwargs...) -> ModelContextProtocol.Server
+
+Construct an MCP server exposing Giac's CAS engine. Returns a `Server` value that
+has not yet been started; call `start!(server)` to enter the STDIO JSON-RPC loop.
+
+`kwargs...` are forwarded to `ModelContextProtocol.mcp_server` — accepted keys
+include `version`, `instructions`, `capabilities`, and `auto_register_dir`.
+
+See `docs/src/extensions/mcp.md` and `specs/070-mcp-server-integration/quickstart.md`
+for setup with Claude Desktop, Claude Code, and other MCP clients.
+"""
+function Giac.giac_mcp_server(;
+    name::AbstractString = "giac-cas",
+    version::AbstractString = string(pkgversion(Giac)),
+    kwargs...,
+)
+    return mcp_server(;
+        name = name,
+        version = version,
+        description = _SERVER_DESCRIPTION,
+        tools = [_make_eval_tool(), _make_search_tool()],
+        kwargs...,
+    )
+end
+
+end # module GiacMCPExt

--- a/src/Giac.jl
+++ b/src/Giac.jl
@@ -155,6 +155,9 @@ using .Commands: hold_cmd, release
 # Conversion functions (extended by GiacSymbolicsExt and GiacMathJSONExt)
 export to_giac, to_symbolics, to_mathjson
 
+# MCP server entry point (extended by GiacMCPExt when ModelContextProtocol is loaded)
+export giac_mcp_server
+
 """
     to_giac(expr)
 
@@ -177,6 +180,36 @@ function to_symbolics end
 Convert a GiacExpr or GiacMatrix to a MathJSON.jl expression. Extended by GiacMathJSONExt.
 """
 function to_mathjson end
+
+"""
+    giac_mcp_server(; name="giac-cas", version=string(pkgversion(Giac)), kwargs...) -> ModelContextProtocol.Server
+
+Construct an MCP (Model Context Protocol) server exposing the Giac CAS engine
+to LLM clients such as Claude Desktop, Claude Code, and Cursor. The returned
+`Server` advertises two tools:
+
+- `giac_eval` — evaluate any Giac/Xcas expression (string in → result out).
+- `giac_search` — search Giac's ~2200 command catalogue by keyword.
+
+The `version` default reflects the currently loaded Giac.jl version, so the
+MCP `initialize` handshake's `serverInfo.version` stays in sync with the
+package automatically.
+
+This function is **extended by `GiacMCPExt` when `ModelContextProtocol` is loaded**.
+Calling it without first loading `ModelContextProtocol` raises a `MethodError`
+with Julia's standard weak-extension diagnostic — install and load
+`ModelContextProtocol.jl` to activate the extension:
+
+```julia
+using Pkg; Pkg.add("ModelContextProtocol")
+using Giac, ModelContextProtocol
+start!(giac_mcp_server())   # blocks on STDIO transport
+```
+
+`kwargs...` are forwarded to `ModelContextProtocol.mcp_server`. See
+`docs/src/extensions/mcp.md` for the full setup guide.
+"""
+function giac_mcp_server end
 
 # Note: Calculus and algebra functions (giac_diff, giac_integrate, giac_factor, etc.)
 # have been removed in favor of Giac.Commands equivalents.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,6 +159,12 @@ using LinearAlgebra
     include("test_terminterface_ext.jl")
 
     # ============================================================================
+    # MCP Server Extension Tests (070-mcp-server-integration)
+    # Verifies the GiacMCPExt extension exposes giac_mcp_server with two tools
+    # ============================================================================
+    include("test_mcp_ext.jl")
+
+    # ============================================================================
     # Doctests
     # Runs jldoctest blocks in Giac docstrings via Documenter.doctest
     # ============================================================================

--- a/test/test_mcp_ext.jl
+++ b/test/test_mcp_ext.jl
@@ -1,0 +1,192 @@
+using Test
+using Giac
+using ModelContextProtocol
+
+# Helper: locate a tool by name from the server's tool list.
+function _find_tool(server, tool_name::AbstractString)
+    idx = findfirst(t -> t.name == tool_name, server.tools)
+    idx === nothing && error("tool \"$tool_name\" not found on server")
+    return server.tools[idx]
+end
+
+@testset "GiacMCPExt" begin
+
+    # ------------------------------------------------------------------
+    # 1. Extension activation (FR-002, FR-009)
+    # ------------------------------------------------------------------
+    @testset "Extension activation" begin
+        @test isdefined(Giac, :giac_mcp_server)
+        @test isa(Giac.giac_mcp_server, Function)
+        # Once ModelContextProtocol is loaded, the zero-arg method exists.
+        @test hasmethod(Giac.giac_mcp_server, Tuple{})
+    end
+
+    # ------------------------------------------------------------------
+    # 2. Server shape (FR-003)
+    # ------------------------------------------------------------------
+    @testset "Server shape" begin
+        server = giac_mcp_server()
+        @test length(server.tools) == 2
+        tool_names = Set(t.name for t in server.tools)
+        @test tool_names == Set(["giac_eval", "giac_search"])
+    end
+
+    # ------------------------------------------------------------------
+    # 3. Eval handler — happy paths (FR-003, FR-004, SC-005)
+    # ------------------------------------------------------------------
+    @testset "Eval handler — happy paths" begin
+        server = giac_mcp_server()
+        eval_tool = _find_tool(server, "giac_eval")
+
+        # Arithmetic
+        result = eval_tool.handler(Dict("expr" => "2+3"))
+        @test isa(result, TextContent)
+        @test occursin("5", result.text)
+
+        # Algebra — factorization
+        result = eval_tool.handler(Dict("expr" => "factor(x^2-1)"))
+        @test isa(result, TextContent)
+        @test occursin("x-1", result.text) || occursin("x - 1", result.text)
+        @test occursin("x+1", result.text) || occursin("x + 1", result.text)
+
+        # Calculus — differentiation
+        result = eval_tool.handler(Dict("expr" => "diff(sin(x^2),x)"))
+        @test isa(result, TextContent)
+        @test occursin("cos", result.text)
+        @test occursin("x^2", result.text) || occursin("x*x", result.text)
+
+        # Laplace transform
+        result = eval_tool.handler(Dict("expr" => "laplace(exp(-t),t,s)"))
+        @test isa(result, TextContent)
+        @test occursin("s+1", result.text) || occursin("s + 1", result.text)
+    end
+
+    # ------------------------------------------------------------------
+    # 4. Eval handler — error path (FR-006, SC-004)
+    # ------------------------------------------------------------------
+    @testset "Eval handler — error path" begin
+        server = giac_mcp_server()
+        eval_tool = _find_tool(server, "giac_eval")
+
+        # Invalid Giac input must NOT throw (the MCP session must stay alive).
+        # Giac itself is forgiving and reports parse errors as a textual "undef"
+        # result via stderr warnings, so the handler returns a TextContent in
+        # that path. When Giac DOES raise a Julia exception (e.g. wrapper-level
+        # failures), our try/catch wraps it as CallToolResult(isError=true).
+        # Either shape satisfies FR-006; both keep the session alive.
+        local result
+        threw = false
+        try
+            result = eval_tool.handler(Dict("expr" => "invalid_syntax(("))
+        catch
+            threw = true
+        end
+        @test !threw
+        @test (isa(result, TextContent) && !isempty(result.text)) ||
+              (isa(result, CallToolResult) && result.isError == true && !isempty(result.content))
+    end
+
+    # ------------------------------------------------------------------
+    # 5. Search handler — basic (FR-005)
+    # ------------------------------------------------------------------
+    @testset "Search handler — basic" begin
+        server = giac_mcp_server()
+        search_tool = _find_tool(server, "giac_search")
+
+        # Keyword match
+        result = search_tool.handler(Dict("query" => "laplace"))
+        @test isa(result, TextContent)
+        @test occursin("laplace", result.text)
+
+        # Explicit empty-match contract
+        result = search_tool.handler(Dict("query" => "xxxxxxxx-no-such"))
+        @test isa(result, TextContent)
+        @test result.text == "No commands matched."
+    end
+
+    # ------------------------------------------------------------------
+    # 6. Re-creation safety (FR-010)
+    # ------------------------------------------------------------------
+    @testset "Re-creation safety" begin
+        s1 = giac_mcp_server()
+        s2 = giac_mcp_server()
+        @test s1 !== s2
+        @test length(s1.tools) == 2
+        @test length(s2.tools) == 2
+    end
+
+    # ------------------------------------------------------------------
+    # 7. Kwarg forwarding (FR-011)
+    # ------------------------------------------------------------------
+    @testset "Kwarg forwarding" begin
+        server = giac_mcp_server(name = "custom-giac")
+        # `Server` stores configuration in `.config`; the server name lives there.
+        @test server.config.name == "custom-giac"
+    end
+
+    @testset "Server version tracks Giac.jl version" begin
+        # serverInfo.version (visible to MCP clients in the initialize handshake)
+        # MUST default to the running Giac.jl version, not the framework's hardcoded
+        # "1.0.0".
+        server = giac_mcp_server()
+        @test server.config.version == string(pkgversion(Giac))
+
+        # User override still wins.
+        server = giac_mcp_server(version = "9.9.9-test")
+        @test server.config.version == "9.9.9-test"
+    end
+
+    # ------------------------------------------------------------------
+    # US2 — stub-export visible (data-model.md Entity 5)
+    # ------------------------------------------------------------------
+    @testset "US2 — public surface" begin
+        @test :giac_mcp_server in names(Giac)
+        @test isa(Giac.giac_mcp_server, Function)
+    end
+
+    # ------------------------------------------------------------------
+    # US3 — search quality across SC-005 keywords
+    # ------------------------------------------------------------------
+    @testset "Search quality — SC-005 keywords" begin
+        server = giac_mcp_server()
+        search_tool = _find_tool(server, "giac_search")
+
+        function _text_for(query::AbstractString)
+            result = search_tool.handler(Dict("query" => query))
+            @test isa(result, TextContent)
+            return result.text
+        end
+
+        # laplace → at least `laplace`
+        text = _text_for("laplace")
+        @test text != "No commands matched."
+        @test occursin("laplace", text)
+
+        # matrix → at least one matrix-related command
+        text = _text_for("matrix")
+        @test text != "No commands matched."
+
+        # prime → at least one prime-related command
+        text = _text_for("prime")
+        @test text != "No commands matched."
+        @test occursin("prime", text)
+
+        # factor → at least `factor`
+        text = _text_for("factor")
+        @test text != "No commands matched."
+        @test occursin("factor", text)
+
+        # integrate → at least `integrate`
+        text = _text_for("integrate")
+        @test text != "No commands matched."
+        @test occursin("integrate", text)
+    end
+
+    @testset "Search quality — explicit empty match" begin
+        server = giac_mcp_server()
+        search_tool = _find_tool(server, "giac_search")
+        result = search_tool.handler(Dict("query" => "xxxxxxxxxxx-no-such-command"))
+        @test result.text == "No commands matched."
+    end
+
+end


### PR DESCRIPTION
Add a weak-dependency package extension GiacMCPExt that exposes Giac.jl's CAS engine to MCP-aware LLM clients (Claude Desktop, Claude Code, Cursor) via ModelContextProtocol.jl. Users who do not load the framework see no behavior change, no manifest entry, and no precompilation cost.

The server advertises two tools:
- giac_eval — evaluate any Giac/Xcas expression; on Julia exceptions the handler returns CallToolResult(isError=true, ...) so the MCP session stays alive (FR-006).
- giac_search — keyword search over the command catalogue, with a prefix-then-substring fallback so LLM-style queries like "matrix" or "prime" surface relevant commands.

serverInfo.version defaults to string(pkgversion(Giac)) so the initialize handshake always reports the running Giac.jl version (0.14.1 today), overridable via the version= kwarg.

Tests cover server shape, eval happy/error paths, search quality across SC-005 keywords, re-creation safety, kwarg forwarding, and version tracking. Aqua remains green; +44 new passing assertions, zero regressions.

Documentation includes a new docs/src/extensions/mcp.md page with Claude Desktop / Claude Code / generic-client setup snippets and a JSON-RPC poke for manual end-to-end validation. Documented under [Unreleased] in CHANGELOG.md — no version bump in this commit.

Documentation : https://s-celles.github.io/Giac.jl/dev/extensions/mcp/