### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-11
+
 ### Added
 
 - **MCP server integration**: `giac_mcp_server()` exposes Giac's CAS engine
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ModelContextProtocol.jl` are unaffected — no transitive dependency, no
   precompilation cost. See `docs/src/extensions/mcp.md` for the full setup
   guide.
-  
+
 - **Example MCP prompts in the documentation**: `docs/src/extensions/mcp.md`
   now ships a curated "Example prompts" gallery — French and English
   direct-style prompts (`factorise avec giac x²-1`, `with giac, factor
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the prime just after one billion — what is it?"*). A separate
   `giac_search` block shows catalogue-discovery prompts
   (*"which commands deal with matrices?"*).
-  
+
 - **Direct `Gen` fast path for `invoke_cmd` / `giac_cmd` (spec 069)**: the
   generic command dispatcher now bypasses the GIAC parser when all arguments
   have a direct `Gen` representation (`GiacExpr`, `Int32`, Int32-fitting
@@ -52,10 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fast path structurally eliminates the `Gen → string → parse → Gen`
   round-trip class of bug that motivated `_giac_subst_vec_tier1` (spec 065).
   Set `GIAC_INVOKE_CMD_STRING_PATH=1` to disable globally.
-
-## [0.14.1] - 2026-05-10
-
-### Added
 
 - **`CONTRIBUTORS.md`**: a top-level acknowledgements file listing the
   people who built, reviewed, and inspired this package — Giac authors

--- a/README.md
+++ b/README.md
@@ -9,48 +9,8 @@
 
 A Julia wrapper for the [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) computer algebra system.
 
-## MCP Server (LLM Integration)
-
-Giac.jl can expose its CAS engine to MCP-aware LLM clients (Claude Desktop,
-Claude Code, Cursor, …) via the
-[Model Context Protocol](https://modelcontextprotocol.io). The integration
-is a weak-dependency package extension on
-[`ModelContextProtocol.jl`](https://github.com/JuliaSMLM/ModelContextProtocol.jl),
-so users who do not need MCP pay no cost.
-
-```julia
-using Pkg; Pkg.add("ModelContextProtocol")   # one-time setup
-using Giac, ModelContextProtocol
-start!(giac_mcp_server())                    # blocks on STDIO transport
-```
-
-### Claude Desktop
-
-Add to `~/.config/claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "giac-cas": {
-      "command": "julia",
-      "args": [
-        "--project=/path/to/env",
-        "-e",
-        "using Giac, ModelContextProtocol; start!(giac_mcp_server())"
-      ]
-    }
-  }
-}
-```
-
-### Claude Code
-
-```bash
-claude mcp add-json "giac-cas" '{"command":"julia","args":["--project=/path/to/env","-e","using Giac, ModelContextProtocol; start!(giac_mcp_server())"]}'
-```
-
-See [`docs/src/extensions/mcp.md`](docs/src/extensions/mcp.md) for the full
-setup guide, manual JSON-RPC test, and the list of advertised tools.
+For LLM integration via the Model Context Protocol, see
+[`docs/src/extensions/mcp.md`](docs/src/extensions/mcp.md).
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

- Fold the `[Unreleased]` entries (MCP server, MCP prompt gallery, direct `Gen` fast path for `invoke_cmd`) into the `[0.14.1]` block.
- Date the release 2026-05-11.
- `Project.toml` already at `0.14.1`; no version bump required.

## Test plan

- [ ] CI green on `release/v0.14.1`
- [ ] After merge, tag `v0.14.1` on the merge commit and push the tag