### PR TITLE
fix(ci): use TAGBOT_PAT so TagBot-created tags trigger workflows

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -27,5 +27,8 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (not GITHUB_TOKEN) so the tag push triggers downstream
+          # workflows like Documentation and CI. Events created with
+          # GITHUB_TOKEN are deliberately not propagated by GitHub Actions.
+          token: ${{ secrets.TAGBOT_PAT }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

- TagBot currently creates tags with `GITHUB_TOKEN`. Per GitHub Actions anti-recursion policy, events created with `GITHUB_TOKEN` do not trigger other workflows — so the Documentation workflow has not fired on any tag since `v0.9.0`. Result: `https://s-celles.github.io/Giac.jl/stable/` is frozen on v0.9.0-era content (still mentions `TempApi`), and there are no per-version docs for `v0.11.x`, `v0.12.0`, `v0.14.0`.
- Switch TagBot to use a fine-grained PAT (`TAGBOT_PAT`) — events from a PAT propagate normally, so the next tag push will trigger Documentation and CI.

## Prerequisite

A repo secret `TAGBOT_PAT` must be set, holding a fine-grained PAT scoped to this repo with: `Contents: Read and write`, `Issues: Read-only`, `Pull requests: Read-only`. (Already added.)

## Test plan

- [ ] PR CI green
- [ ] After merge, the next TagBot-created tag triggers the Documentation workflow
- [ ] `versions.js` advances past `v0.9.0` and `/stable/` reflects the latest tagged release